### PR TITLE
Add ratelimit to xp gain & prevent location being easily leaked

### DIFF
--- a/components/storeGame.js
+++ b/components/storeGame.js
@@ -1,8 +1,7 @@
 import mongoose from 'mongoose';
 import User from '../models/User';
-import ratelimiter from "./utils/ratelimitMiddleware";
 
-async function storeGame(secret, xp, timeTaken, latLong) {
+export default async function storeGame(secret, xp, timeTaken, latLong) {
 
   // Connect to MongoDB
   if (mongoose.connection.readyState !== 1) {
@@ -47,6 +46,3 @@ async function storeGame(secret, xp, timeTaken, latLong) {
   await user.save();
   return { success: true };
 }
-
-// Limit to 1 request per 5 seconds over a minute, generous limit but better than nothing
-export default ratelimiter(storeGame, 12, 60000)

--- a/components/utils/ratelimitMiddleware.js
+++ b/components/utils/ratelimitMiddleware.js
@@ -11,7 +11,7 @@ export default function ratelimitMiddleware(handler, limit, windowMs) {
     // note: this ip can be spoofed when the site is not behind cloudflare
     const ip = req.headers["x-forwarded-for"] || req.connection.remoteAddress;
     
-    const ipLimit = undefined;
+    let ipLimit = undefined;
     if (!ipLimitTracker.has(ip)) {
       ipLimitTracker.set(ip, defaultData);
       ipLimit = defaultData;

--- a/components/utils/ratelimitMiddleware.js
+++ b/components/utils/ratelimitMiddleware.js
@@ -1,0 +1,37 @@
+// middleware to add a limit on endpoints. limit is the limit of requests within the windowMs
+export default function ratelimitMiddleware(handler, limit, windowMs) {
+  const ipLimitTracker = new Map();
+
+  const defaultData = {
+    requests: 0,
+    windowStart: Date.now(),
+  };
+
+  return async (req, res) => {
+    // note: this ip can be spoofed when the site is not behind cloudflare
+    const ip = req.headers["x-forwarded-for"] || req.connection.remoteAddress;
+    
+    const ipLimit = undefined;
+    if (!ipLimitTracker.has(ip)) {
+      ipLimitTracker.set(ip, defaultData);
+      ipLimit = defaultData;
+    } else {
+      ipLimit = ipLimitTracker.get(ip)
+    }
+    
+    const timeSinceWindow = Date.now() - ipLimit.windowStart
+    if (timeSinceWindow > windowMs) {
+      ipLimit.requests = 0;
+      ipLimit.windowStart = Date.now();
+    }
+    
+    if (ipLimit.requests >= limit) {
+      return res.status(429).send("Too Many Requests");
+    }
+    
+    ipLimit.requests += 1;
+    
+    // await to support async handlers
+    return await handler(req, res);
+  };
+}

--- a/pages/api/storeGame.js
+++ b/pages/api/storeGame.js
@@ -1,7 +1,9 @@
 import calcPoints from '@/components/calcPoints';
 import storeGame from '@/components/storeGame';
+import ratelimiter from '@/components/utils/ratelimitMiddleware'
+
 // multiplayer after guess
-export default async function guess(req, res) {
+async function guess(req, res) {
   const { lat, long, actualLat, actualLong, usedHint, secret, roundTime, maxDist } = req.body;
 
   // secret must be string
@@ -24,3 +26,6 @@ export default async function guess(req, res) {
   }
   res.status(200).json({ success: true });
 }
+
+// Limit to 1 request per 5 seconds over a minute, generous limit but better than nothing
+export default ratelimiter(guess, 12, 60000)

--- a/pages/index.js
+++ b/pages/index.js
@@ -1117,7 +1117,7 @@ export default function Home({ locale }) {
     window.panorama = panoramaRef.current;
   } else {
 
-    console.log("setting position", latLong)
+    console.log("setting position")
     panoramaRef.current.setPosition({ lat: latLong.lat, lng: latLong.long });
 
     window.reloadLoc = () => {


### PR DESCRIPTION
These changes add a rate-limit to XP gain and remove the location being outputted to the developer console.

The rate-limit is set to 1 request every 5 seconds over 60 seconds, this prevents people from sending hundreds of requests per second.

Additionally, the location was removed from the developer console, this makes it harder for people to cheat in public games with a large timer.