### PR TITLE
chore: fixed username taken ambiguity text

### DIFF
--- a/api/setName.js
+++ b/api/setName.js
@@ -1,67 +1,79 @@
 // pages/api/setName.js
-import User from '../models/User.js';
+import User from "../models/User.js";
 import { Webhook } from "discord-webhook-node";
-import { USERNAME_CHANGE_COOLDOWN } from './publicAccount.js';
-import Map from '../models/Map.js';
-import cachegoose from 'recachegoose';
-import { Filter } from 'bad-words';
+import { USERNAME_CHANGE_COOLDOWN } from "./publicAccount.js";
+import Map from "../models/Map.js";
+import cachegoose from "recachegoose";
+import { Filter } from "bad-words";
 const filter = new Filter();
 
 export default async function handler(req, res) {
   // Only allow POST requests
-  if (req.method !== 'POST') {
-    return res.status(405).json({ message: 'Method not allowed' });
+  if (req.method !== "POST") {
+    return res.status(405).json({ message: "Method not allowed" });
   }
-
 
   // Extract the token and username from the request body
   const { token, username } = req.body;
-  if (typeof token !== 'string' || typeof username !== 'string') {
-    return res.status(400).json({ message: 'Invalid input' });
+  if (typeof token !== "string" || typeof username !== "string") {
+    return res.status(400).json({ message: "Invalid input" });
   }
   if (!token || !username) {
-    return res.status(400).json({ message: 'Missing token or username' });
+    return res.status(400).json({ message: "Missing token or username" });
   }
 
   // Ensure username meets criteria
   if (username.length < 3 || username.length > 30) {
-    return res.status(400).json({ message: 'Username must be between 3 and 30 characters' });
+    return res
+      .status(400)
+      .json({ message: "Username must be between 3 and 30 characters" });
   }
   // Alphanumeric characters and underscores only
   if (!/^[a-zA-Z0-9_]+$/.test(username)) {
-    return res.status(400).json({ message: 'Username must contain only letters, numbers, and underscores' });
+    return res
+      .status(400)
+      .json({
+        message: "Username must contain only letters, numbers, and underscores",
+      });
   }
   // make sure username is not profane
   if (filter.isProfane(username)) {
-    return res.status(400).json({ message: 'Inappropriate content' });
+    return res.status(400).json({ message: "Inappropriate content" });
   }
   // Make sure the username is unique (case-insensitive)
   const lowerUsername = username.toLowerCase();
 
   // quey check for username (case-insensitive)
-  const existing = await User.findOne({ username: { $regex: new RegExp(`^${lowerUsername}$`, 'i') } });
+  const existing = await User.findOne({
+    username: { $regex: new RegExp(`^${lowerUsername}$`, "i") },
+  });
   if (existing) {
-    return res.status(400).json({ message: 'Username taken' });
+    return res
+      .status(400)
+      .json({ message: "Username already taken, please select a new one" });
   }
-
-
 
   try {
     // Find user by the provided token
     const user = await User.findOne({ secret: token });
     if (!user) {
-      return res.status(404).json({ message: 'User not found' });
+      return res.status(404).json({ message: "User not found" });
     }
-    if(user.username) {
+    if (user.username) {
       // this means this is a name change, not a first time name set
       // check if the user has waited long enough since the last name change
-      if (user.lastNameChange && Date.now() - user.lastNameChange < USERNAME_CHANGE_COOLDOWN) {
-        return res.status(400).json({ message: 'You must wait 30 days between name changes' });
+      if (
+        user.lastNameChange &&
+        Date.now() - user.lastNameChange < USERNAME_CHANGE_COOLDOWN
+      ) {
+        return res
+          .status(400)
+          .json({ message: "You must wait 30 days between name changes" });
       }
       user.lastNameChange = Date.now();
 
       // update users map with new username
-      const userMaps = await Map.find({created_by: user._id});
+      const userMaps = await Map.find({ created_by: user._id });
       for (const map of userMaps) {
         map.map_creator_name = username;
         await map.save();
@@ -69,11 +81,10 @@ export default async function handler(req, res) {
 
       // recachegoose clear key publicData_${id}
       cachegoose.clearCache(`publicData_${user._id.toString()}`, (error) => {
-        if(error) {
-          console.error('Error clearing cache', error);
+        if (error) {
+          console.error("Error clearing cache", error);
         }
       });
-
     }
 
     // Update the user's username
@@ -92,6 +103,8 @@ export default async function handler(req, res) {
 
     res.status(200).json({ success: true });
   } catch (error) {
-    res.status(500).json({ message: 'Server error', error: error.message, success:false });
+    res
+      .status(500)
+      .json({ message: "Server error", error: error.message, success: false });
   }
 }


### PR DESCRIPTION
When we add username, in the home page after loggin in via Google, we are asked to add username. After adding a username, if that name already exists, the alert says "username taken", which might convey a different meaning as in "the new username is taken by the system and added it to database", so clarification of the message will help user get more clearer response as  "Username already taken, please select a new one" is more meaningful.