### PR TITLE
disable keyboard shortcuts while in nomove

### DIFF
--- a/components/streetview/streetView.js
+++ b/components/streetview/streetView.js
@@ -111,6 +111,17 @@ const StreetView = ({
       setLoading(false);
       cleanMetaTags();
     });
+    if (typeof window !== "undefined") {
+      window.addEventListener(
+        'keydown',
+        (event) => {
+          if (nm && (event.key.toLowerCase() === 'w' || event.key.toLowerCase() === 's')) {
+            event.stopPropagation()
+          };
+        },
+        { capture: true },
+      );
+    }
   };
 
   // Main useEffect for handling embed or SDK


### PR DESCRIPTION
Intercepting the keydowns in streetview embed seems to work well to stop the keyboard shortcuts.

Doesnt interfere with chatbox because it seems to not have the embed in focus, is my assumption as to why it should work. Tested in both chrome and firefox