### PR TITLE
Always show the decimal fraction in countdown

### DIFF
--- a/components/gameUI.js
+++ b/components/gameUI.js
@@ -640,14 +640,14 @@ text("round", {r:multiplayerState?.gameData?.curRound, mr: multiplayerState?.gam
 
 :
 
-      text("roundTimer", {r:multiplayerState?.gameData?.curRound, mr: multiplayerState?.gameData?.rounds, t: timeToNextMultiplayerEvt})}
+      text("roundTimer", {r:multiplayerState?.gameData?.curRound, mr: multiplayerState?.gameData?.rounds, t: timeToNextMultiplayerEvt.toFixed(1)})}
         </span>
 
         <span className={`timer ${!onboardingTimerShown ? '' : 'shown'}`}>
 
 {/* Round #{multiplayerState?.gameData?.curRound} / {multiplayerState?.gameData?.rounds} - {timeToNextMultiplayerEvt}s */}
       {timeToNextRound ?
-      text("roundTimer", {r:onboarding?.round, mr: 5, t: timeToNextRound})
+      text("roundTimer", {r:onboarding?.round, mr: 5, t: timeToNextRound.toFixed(1)})
       : text("round", {r:onboarding?.round, mr: 5})}
 
         </span>


### PR DESCRIPTION
To reduce the flickering/jumpiness of the countdown text, this change always shows the first fraction of seconds, even for integers.