### PR TITLE
fix: Exclude elo_refund entries from user progression query

### DIFF
--- a/components/utils/userStatsService.js
+++ b/components/utils/userStatsService.js
@@ -86,7 +86,10 @@ class UserStatsService {
    */
   static async getUserProgression(userId, days = null) {
     try {
-      const query = { userId: userId };
+      const query = { 
+        userId: userId,
+        triggerEvent: { $ne: 'elo_refund' } // Exclude elo_refund entries from progression
+      };
 
       // Only add timestamp filter if days is specified
       if (days !== null) {


### PR DESCRIPTION
- Updated the user progression query in UserStatsService to exclude entries with the triggerEvent 'elo_refund', ensuring more accurate user statistics.
- This change improves the integrity of user progression data by filtering out specific events that may skew results.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures user progression charts ignore refund-related entries for accurate trends.
> 
> - Update `getUserProgression` to filter `triggerEvent: { $ne: 'elo_refund' }` while preserving optional `days` timestamp filter and sorting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e806edceda691976cfc9dadce44715bc86e3ee7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->