### PR TITLE
fix: improved compass visibility and size (#97)

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -3474,7 +3474,10 @@ input[placeholder="Please login to chat"] {
 }
 
 .gm-compass {
-    transform: translateY(50%);
+    transform: scale(1.5) !important;
+    filter: drop-shadow(0px 0px 5px rgba(0, 0, 0, 0.7)) !important;
+    z-index: 1000 !important;
+    transition: transform 0.2s ease-in-out;
 }
 
 .streetview.nmpz .gm-compass {


### PR DESCRIPTION
This PR addresses the issue where the compass was too small and difficult to see during gameplay. I increased the scale and added a drop-shadow to the .gm-compass class in the global styles to improve visibility and user experience. Closes #97.