### PR TITLE
Add in-game global chat for multiplayer matches

### DIFF
--- a/components/gameChat.js
+++ b/components/gameChat.js
@@ -1,0 +1,123 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import CountryFlag from '@/components/utils/countryFlag';
+
+const SEND_COOLDOWN = 2000;
+const MAX_MESSAGES = 50;
+
+function GameChat({ ws, inGame, myId }) {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [open, setOpen] = useState(false);
+  const [lastSent, setLastSent] = useState(0);
+  const [unread, setUnread] = useState(0);
+  const messagesEndRef = useRef(null);
+  const myIdRef = useRef(myId);
+
+  useEffect(() => { myIdRef.current = myId; }, [myId]);
+
+  useEffect(() => {
+    if (!ws) return;
+    const onMessage = (evt) => {
+      let data;
+      try { data = JSON.parse(evt.data); } catch { return; }
+      if (data.type !== 'chat') return;
+      if (typeof data.message !== 'string') return;
+
+      setMessages(prev => [...prev.slice(-(MAX_MESSAGES - 1)), {
+        id: Date.now() + Math.random(),
+        name: data.name || 'Guest',
+        countryCode: data.countryCode || null,
+        message: data.message,
+        isSelf: data.id === myIdRef.current,
+      }]);
+      setUnread(prev => prev + 1);
+    };
+    ws.addEventListener('message', onMessage);
+    return () => ws.removeEventListener('message', onMessage);
+  }, [ws]);
+
+  // Clear messages when leaving game
+  useEffect(() => {
+    if (!inGame) {
+      setMessages([]);
+      setUnread(0);
+      setOpen(false);
+    }
+  }, [inGame]);
+
+  // Clear unread when opening
+  useEffect(() => {
+    if (open) setUnread(0);
+  }, [open]);
+
+  // Auto-scroll
+  useEffect(() => {
+    if (open) {
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages, open]);
+
+  const sendChat = useCallback((e) => {
+    if (e) e.preventDefault();
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    if (!input.trim()) return;
+    if (Date.now() - lastSent < SEND_COOLDOWN) return;
+    ws.send(JSON.stringify({ type: 'chat', message: input.trim().substring(0, 200) }));
+    setInput('');
+    setLastSent(Date.now());
+  }, [ws, input, lastSent]);
+
+  if (!inGame) return null;
+
+  return (
+    <div className="gameChat">
+      <button
+        className={`gameChatToggle ${open ? 'open' : ''}`}
+        onClick={() => setOpen(o => !o)}
+        aria-label="Toggle chat"
+        type="button"
+      >
+        <svg viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        </svg>
+        {!open && unread > 0 && <span className="gameChatBadge">{unread > 9 ? '9+' : unread}</span>}
+      </button>
+      {open && (
+        <div className="gameChatPanel">
+          <div className="gameChatMessages">
+            {messages.length === 0 && (
+              <div className="gameChatEmpty">No messages yet</div>
+            )}
+            {messages.map(m => (
+              <div key={m.id} className={`gameChatMsg ${m.isSelf ? 'self' : ''}`}>
+                <span className="gameChatMsgName">
+                  {m.countryCode && <CountryFlag countryCode={m.countryCode} style={{ fontSize: '0.8em', marginRight: '3px' }} />}
+                  {m.name}:
+                </span>
+                <span className="gameChatMsgText">{m.message}</span>
+              </div>
+            ))}
+            <div ref={messagesEndRef} />
+          </div>
+          <form className="gameChatInputArea" onSubmit={sendChat}>
+            <input
+              className="gameChatInput"
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              maxLength={200}
+              placeholder="Type a message..."
+              autoComplete="off"
+            />
+            <button className="gameChatSendBtn" type="submit" aria-label="Send message">
+              <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
+                <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/>
+              </svg>
+            </button>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default React.memo(GameChat);

--- a/components/home.js
+++ b/components/home.js
@@ -39,6 +39,7 @@ const MapGuessrModal = dynamic(() => import('@/components/mapGuessrModal'), { ss
 import MultiplayerHome from "@/components/multiplayerHome";
 import SetUsernameModal from "@/components/setUsernameModal";
 import EmoteReactions from "@/components/emoteReactions";
+import GameChat from "@/components/gameChat";
 import SettingsModal from "@/components/settingsModal";
 import WelcomeOverlay from "@/components/welcomeOverlay";
 import OnboardingComplete from "@/components/onboardingComplete";
@@ -2819,6 +2820,12 @@ export default function Home({ initialScreen, dailyBootstrap } = {}) {
         rightSide={multiplayerState?.inGame && multiplayerState?.gameData?.state === 'end'}
     />, [ws, multiplayerEmotesEnabled, multiplayerState?.inGame, multiplayerState?.gameData?.myId, multiplayerState?.gameData?.duel, multiplayerState?.gameData?.state])
 
+    const GameChatMemo = React.useMemo(() => <GameChat
+        ws={ws}
+        inGame={multiplayerState?.inGame}
+        myId={multiplayerState?.gameData?.myId}
+    />, [ws, multiplayerState?.inGame, multiplayerState?.gameData?.myId])
+
     // Send pong every 10 seconds if websocket is connected
     useEffect(() => {
         const pongInterval = setInterval(() => {
@@ -2923,6 +2930,7 @@ export default function Home({ initialScreen, dailyBootstrap } = {}) {
             {mapGuessrModal && <MapGuessrModal isOpen={true} onClose={() => setMapGuessrModal(false)} />}
             {pendingNameChangeModal && <PendingNameChangeModal session={session} isOpen={true} onClose={() => setPendingNameChangeModal(false)} />}
             {!process.env.NEXT_PUBLIC_SCHOOLGUESSR && EmoteReactionsMemo}
+            {!process.env.NEXT_PUBLIC_SCHOOLGUESSR && GameChatMemo}
             <ToastContainer pauseOnFocusLoss={false} />
 
             {welcomeOverlayShown && screen === "onboarding" && (

--- a/serverUtils/chatFilter.js
+++ b/serverUtils/chatFilter.js
@@ -1,0 +1,113 @@
+// Bad words filter for game chat
+// Matches exact words, common letter substitutions, and partial obfuscations
+
+const BAD_WORDS = [
+  // English slurs and profanity
+  'nigga', 'nigger', 'nigg3r', 'n1gger', 'n1gga', 'niga', 'niger',
+  'faggot', 'fag', 'f4g', 'f4ggot',
+  'retard', 'retarded',
+  'kike',
+  'chink',
+  'spic', 'sp1c',
+  'wetback',
+  'coon',
+  'tranny',
+  // Common profanity
+  'fuck', 'fuk', 'fck', 'f*ck', 'fucc', 'phuck', 'fuck you',
+  'shit', 'sh1t', 'sht', 'sh!t',
+  'bitch', 'b1tch', 'b!tch', 'biatch',
+  'asshole', 'a$$hole', 'assh0le',
+  'cunt', 'c*nt', 'cvnt',
+  'dick', 'd1ck',
+  'cock', 'c0ck',
+  'pussy', 'pvssy', 'pu$$y',
+  'whore', 'wh0re',
+  'slut', 'sl*t',
+  // Spanish
+  'puta', 'puto', 'pendejo', 'pendeja', 'marica', 'maricón', 'maricon',
+  'mierda', 'verga', 'chinga', 'pinche', 'cabron', 'cabrón', 'coño', 'cono',
+  'negro de mierda', 'sudaca',
+  // Portuguese
+  'porra', 'caralho', 'viado', 'putinha',
+  // French
+  'putain', 'merde', 'enculé', 'encule', 'salope', 'connard', 'connasse',
+  'nègre', 'negre',
+  // German
+  'scheiße', 'scheisse', 'hurensohn', 'fotze', 'wichser', 'arschloch',
+  // Russian (transliterated)
+  'suka', 'blyat', 'blyad', 'pidar', 'pidor', 'nahui', 'ebat',
+  'mudak', 'gandon', 'huy',
+  // Additional hate terms
+  'nazi', 'hitler', 'heil',
+  'kill yourself', 'kys',
+];
+
+// Build regex patterns that handle common substitutions
+const SUBSTITUTIONS = {
+  'a': '[a@4àáâãäå]',
+  'e': '[e3èéêë€]',
+  'i': '[i1!|ìíîï]',
+  'o': '[o0òóôõö]',
+  'u': '[uùúûü]',
+  's': '[s$5]',
+  'g': '[g9]',
+  'l': '[l1|]',
+  't': '[t7+]',
+};
+
+// Create regex-safe pattern from a word, replacing known chars with their substitution classes
+function buildPattern(word) {
+  let pattern = '';
+  for (const ch of word.toLowerCase()) {
+    if (SUBSTITUTIONS[ch]) {
+      pattern += SUBSTITUTIONS[ch];
+    } else if (/[.*+?^${}()|[\]\\]/.test(ch)) {
+      pattern += '\\' + ch;
+    } else {
+      pattern += ch;
+    }
+  }
+  return pattern;
+}
+
+// Pre-compile all patterns
+const PATTERNS = BAD_WORDS.map(word => {
+  const pattern = buildPattern(word);
+  // For short words (<=3 chars), require word boundaries to avoid false positives
+  if (word.length <= 3) {
+    return new RegExp(`\\b${pattern}\\b`, 'i');
+  }
+  return new RegExp(pattern, 'i');
+});
+
+/**
+ * Check if a message contains bad words.
+ * Returns true if the message is clean, false if it contains bad words.
+ */
+export function isCleanMessage(message) {
+  // Normalize: collapse repeated chars (e.g. "fuuuuck" -> "fuck")
+  const normalized = message.replace(/(.)\1{2,}/g, '$1$1');
+
+  for (const pattern of PATTERNS) {
+    if (pattern.test(message) || pattern.test(normalized)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Sanitize message - replace bad words with asterisks
+ */
+export function censorMessage(message) {
+  let result = message;
+  const normalized = message.replace(/(.)\1{2,}/g, '$1$1');
+
+  for (let i = 0; i < PATTERNS.length; i++) {
+    const pattern = PATTERNS[i];
+    // Use global version for replacement
+    const globalPattern = new RegExp(pattern.source, 'gi');
+    result = result.replace(globalPattern, (match) => '*'.repeat(match.length));
+  }
+  return result;
+}

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -3305,6 +3305,204 @@ h1, h2, h3, span, label {
     }
 }
 
+/* ===== Game Chat ===== */
+.gameChat {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    z-index: 1999;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+}
+
+.gameChatToggle {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    border: none;
+    background: rgba(30, 30, 30, 0.85);
+    color: #fff;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.4);
+    transition: background 0.2s, transform 0.2s;
+    position: relative;
+}
+
+.gameChatToggle:hover {
+    background: rgba(50, 50, 50, 0.95);
+    transform: scale(1.05);
+}
+
+.gameChatToggle.open {
+    background: rgba(60, 60, 60, 0.95);
+}
+
+.gameChatBadge {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    background: #e74c3c;
+    color: #fff;
+    font-size: 11px;
+    font-weight: 700;
+    border-radius: 50%;
+    min-width: 18px;
+    height: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 4px;
+    line-height: 1;
+}
+
+.gameChatPanel {
+    position: absolute;
+    bottom: 58px;
+    right: 0;
+    width: 320px;
+    max-height: 400px;
+    background: rgba(20, 20, 20, 0.92);
+    backdrop-filter: blur(8px);
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+    animation: gameChatSlideUp 0.2s ease-out;
+}
+
+@keyframes gameChatSlideUp {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.gameChatMessages {
+    flex: 1;
+    overflow-y: auto;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    max-height: 320px;
+    min-height: 120px;
+}
+
+.gameChatMessages::-webkit-scrollbar {
+    width: 4px;
+}
+
+.gameChatMessages::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 2px;
+}
+
+.gameChatEmpty {
+    color: rgba(255, 255, 255, 0.4);
+    font-size: 13px;
+    text-align: center;
+    padding: 20px 0;
+}
+
+.gameChatMsg {
+    font-size: 13px;
+    line-height: 1.4;
+    color: #eee;
+    word-break: break-word;
+}
+
+.gameChatMsg.self .gameChatMsgName {
+    color: #6ecf6e;
+}
+
+.gameChatMsgName {
+    font-weight: 600;
+    color: #aaa;
+    margin-right: 5px;
+    font-size: 12px;
+}
+
+.gameChatMsgText {
+    color: #fff;
+}
+
+.gameChatInputArea {
+    display: flex;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 8px;
+    gap: 6px;
+}
+
+.gameChatInput {
+    flex: 1;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 8px;
+    padding: 8px 12px;
+    color: #fff;
+    font-size: 13px;
+    outline: none;
+    transition: border-color 0.2s;
+}
+
+.gameChatInput:focus {
+    border-color: rgba(255, 255, 255, 0.35);
+}
+
+.gameChatInput::placeholder {
+    color: rgba(255, 255, 255, 0.35);
+}
+
+.gameChatSendBtn {
+    background: #4a9eff;
+    border: none;
+    border-radius: 8px;
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.gameChatSendBtn:hover {
+    background: #3a8eef;
+}
+
+@media (max-width: 768px) {
+    .gameChat {
+        bottom: 12px;
+        right: 12px;
+    }
+
+    .gameChatPanel {
+        width: 280px;
+        max-height: 300px;
+    }
+
+    .gameChatMessages {
+        max-height: 220px;
+    }
+
+    body:has(#miniMapArea.shown.answerNotShown) .gameChat {
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+    }
+}
+
 .multiplayerLeaderboard {
     border-radius: 10px;
     position: fixed;

--- a/ws/ws.js
+++ b/ws/ws.js
@@ -18,6 +18,7 @@ import calculateOutcomes from '../components/utils/eloSystem.js';
 import { tmpdir } from 'os';
 
 import arbitraryWorld from '../data/world-arbitrary.json' with { type: "json" };
+import { isCleanMessage, censorMessage } from '../serverUtils/chatFilter.js';
 config();
 
 console.log("[INFO] Starting ws.js")
@@ -773,6 +774,28 @@ app.ws('/wg', {
           name: player.username,
           countryCode: player.countryCode || null,
           emote
+        });
+      }
+
+      if (json.type === 'chat' && player.gameId && games.has(player.gameId)) {
+        const msg = json.message;
+        // Validate: must be string, non-empty, max 200 chars
+        if (typeof msg !== 'string' || !msg.trim() || msg.length > 200) return;
+        // Rate limit: 1 message every 2 seconds
+        const now = Date.now();
+        if (player.lastChat && now - player.lastChat < 2000) return;
+        player.lastChat = now;
+        // Banned players cannot chat
+        if (player.banned) return;
+        // Censor bad words
+        const cleanMsg = censorMessage(msg.trim().substring(0, 200));
+        const game = games.get(player.gameId);
+        game.sendAllPlayers({
+          type: 'chat',
+          id: player.id,
+          name: player.username || 'Guest',
+          countryCode: player.countryCode || null,
+          message: cleanMsg,
         });
       }
 


### PR DESCRIPTION
Adds a real-time text chat visible during multiplayer games. Players can open a chat panel (bottom-right bubble icon) to send and receive messages broadcast to all players in the same match. Messages are validated and censored server-side using a custom profanity filter that handles leet-speak substitutions and multiple languages (EN, ES, PT, FR, DE, RU). Security measures include a 2-second rate limit per player, 200-character max length, banned player exclusion, and React's default XSS escaping.
No raw HTML rendering (React escapes by default)
How it works
Players see a chat bubble icon (bottom-right) during any multiplayer game. Clicking it opens a chat panel. Messages are broadcast to all players in the same game instance via [game.sendAllPlayers()](vscode-file://vscode-app/c:/Users/Felipe/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html).