### PR TITLE
Fix two production client-side crashes (TDZ + DOM removeChild)

### DIFF
--- a/components/roundOverScreen.js
+++ b/components/roundOverScreen.js
@@ -657,6 +657,16 @@ const GameSummary = ({
     return [];
   }, [history, multiplayerState?.gameData?.roundHistory, multiplayerState?.gameData?.myId, multiplayerState?.gameData?.duel, multiplayerState?.gameData?.public]);
 
+  // Alias used by the map helpers (fitMapToBounds/focusOnRound) and the map-fit
+  // effect below. It MUST be declared here — before the early returns and before
+  // those closures could ever run — so it is always initialized on every render
+  // that commits. Previously it lived after the early returns (empty history /
+  // Leaflet not ready); on a bail-out render the `const` stayed in its temporal
+  // dead zone, and when React later flushed the passive map-fit effect it read
+  // `finalHistory.length` and threw "Cannot access 'finalHistory' before
+  // initialization", which Next.js surfaced as a fatal client-side crash.
+  const finalHistory = gameHistory;
+
   // Compute the map's initial bounds from round locations + guesses up front
   // so MapContainer mounts already fitted to them. Passing `bounds` to a v4
   // MapContainer runs fitBounds at map creation, so the very first tile fetch
@@ -780,9 +790,6 @@ const GameSummary = ({
   //     </div>
   //   );
   // }
-
-  // Use the constructed or provided history
-  const finalHistory = gameHistory;
 
   // Helper function to open report modal
   const handleReportUser = (accountId, username) => {

--- a/lib/errorTracking.js
+++ b/lib/errorTracking.js
@@ -94,6 +94,47 @@ function formatStack(err) {
   return `${msg}${stack}`;
 }
 
+// Defensive guards for React's commit phase vs. third-party DOM mutations.
+//
+// The ad SDK (scalibur) and browser auto-translate both reach into the live DOM
+// and detach or move nodes that React still believes it owns. When React's
+// reconciler later calls removeChild / insertBefore on a node whose parent has
+// already changed, the browser throws an uncaught NotFoundError ("The node to be
+// removed is not a child of this node"), which white-screens the whole app.
+//
+// Patching these two methods to recover — instead of throw — when the parent no
+// longer matches keeps React's tree stale for at most one frame (the next render
+// reconciles correctly) while preventing the fatal crash. This is the
+// well-known facebook/react#11538 mitigation. Installed once, before hydration.
+function installDomMutationGuards() {
+  if (typeof window === 'undefined' || typeof Node !== 'function' || !Node.prototype) return;
+  if (window.__domMutationGuardsInstalled) return;
+  window.__domMutationGuardsInstalled = true;
+
+  const originalRemoveChild = Node.prototype.removeChild;
+  Node.prototype.removeChild = function (child) {
+    if (child && child.parentNode !== this) {
+      // The node was moved/detached by an ad script or the translator. Remove it
+      // from wherever it actually lives so the DOM still ends up clean, then
+      // return it without throwing.
+      if (child.parentNode) {
+        try { return originalRemoveChild.call(child.parentNode, child); } catch (_) { /* noop */ }
+      }
+      return child;
+    }
+    return originalRemoveChild.apply(this, arguments);
+  };
+
+  const originalInsertBefore = Node.prototype.insertBefore;
+  Node.prototype.insertBefore = function (newNode, referenceNode) {
+    if (referenceNode && referenceNode.parentNode !== this) {
+      // Reference node is no longer our child; append instead of throwing.
+      return this.appendChild(newNode);
+    }
+    return originalInsertBefore.apply(this, arguments);
+  };
+}
+
 export default function installErrorTracking() {
   if (typeof window === 'undefined') return () => {};
   if (window.__errorTrackingInstalled) {
@@ -102,6 +143,8 @@ export default function installErrorTracking() {
       : () => {};
   }
   window.__errorTrackingInstalled = true;
+
+  installDomMutationGuards();
 
   const recentlySent = new Map(); // description -> timestamp
   let translationObserver = null;


### PR DESCRIPTION
roundOverScreen: declare `finalHistory` before the early returns so the passive map-fit effect never reads it in its temporal dead zone. On bail-out renders (empty history / Leaflet not ready) the const was left uninitialized, crashing with "Cannot access 'finalHistory' before initialization" — the most frequent fatal client-side exception.

errorTracking: install defensive Node.prototype.removeChild/insertBefore guards (facebook/react#11538) so third-party DOM mutations (ad SDK scalibur / browser auto-translate) can't throw an uncaught NotFoundError during React's commit phase and white-screen the app.