### PR TITLE
Feature/minimap fullscreen hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ A free and open-source version of the popular geography game inspired by GeoGues
 
 | Key | Action |
 | --- | --- |
-| `Space` | Guess or continue to the next round |
-| `F` | Toggle minimap fullscreen |
-| `H` | Show hint |
+| <kbd>Space</kbd> | Guess or continue to the next round |
+| <kbd>F</kbd> | Toggle minimap fullscreen |
+| <kbd>H</kbd> | Show hint |
 
 ## Acknowledgements
 
@@ -67,7 +67,8 @@ Before you start, ensure you have the following installed:
 
 ## Deploying to a VPS / External Server
 
-If you're deploying WorldGuessr on a VPS or any server with an external IP (not localhost), you **must** configure these environment variables in your `.env` file:
+> [!IMPORTANT]
+> If you're deploying WorldGuessr on a VPS or any server with an external IP (not localhost), you **must** configure these environment variables in your `.env` file:
 
 ```bash
 # Replace YOUR_IP with your server's IP address or domain
@@ -102,7 +103,8 @@ NEXT_PUBLIC_WS_HOST=ws.yourdomain.com
 
 3. **API/WS URLs** - Point to your external IP or domain (see above)
 
-For detailed environment variable documentation, see [docs/environment-variables.md](docs/environment-variables.md).
+> [!TIP]
+> For detailed environment variable documentation, see [docs/environment-variables.md](docs/environment-variables.md).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ A free and open-source version of the popular geography game inspired by GeoGues
 - **Country Streaks:** Test your knowledge and see how many countries you can guess in a row.
 - **Free to run:** The project is open-source and free to run on your own server. Uses the [Google Maps Streetview Embed API](https://developers.google.com/streetview/web), which is completely free compared to the costly SDK used by GeoGuessr.
 
+## Hotkeys
+
+| Key | Action |
+| --- | --- |
+| `Space` | Guess or continue to the next round |
+| `F` | Toggle minimap fullscreen |
+
 ## Acknowledgements
 
 - [Leaflet](https://leafletjs.com/) for the minimap display.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@
 A free and open-source version of the popular geography game inspired by GeoGuessr. This React based project aims to provide a fun and educational way to explore the world through Google Street View imagery.
 
 ### Play now [here](https://worldguessr.com)!
-#### [Join the Discord community](https://discord.gg/yenVspFmkB)
+
+[![Discord][discord-badge]][discord-url]
+[![License][license-badge]][license-url]
 
 ## Features
 
@@ -128,3 +130,8 @@ Distributed under the PolyForm Noncommercial License 1.0.0. You are free to use,
 Join the Discord community [here](https://discord.gg/yenVspFmkB) to discuss new features, report bugs, talk to the developers and connect with other players.
 
 You can email me privately at gautam@worldguessr.com
+
+[discord-badge]: https://img.shields.io/badge/Discord-Join%20community-5865F2?logo=discord&logoColor=white
+[discord-url]: https://discord.gg/yenVspFmkB
+[license-badge]: https://img.shields.io/badge/License-PolyForm%20Noncommercial-blue
+[license-url]: https://polyformproject.org/licenses/noncommercial/1.0.0

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A free and open-source version of the popular geography game inspired by GeoGues
 - [Google Maps API](https://developers.google.com/maps) for the generous free-tier on street view imagery.
 - [Vali](https://github.com/slashP/Vali) by @SlashP for generating balanced locations distributions for all countries.
 - [Next.js](https://nextjs.org/) for the web application.
-- All contributors who helped bring this project to life!
+- All [contributors](https://github.com/codergautam/worldguessr/graphs/contributors?all=1) who helped bring this project to life!
 
 ## Running Locally
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A free and open-source version of the popular geography game inspired by GeoGues
 | --- | --- |
 | `Space` | Guess or continue to the next round |
 | `F` | Toggle minimap fullscreen |
+| `H` | Show hint |
 
 ## Acknowledgements
 

--- a/components/gameUI.js
+++ b/components/gameUI.js
@@ -659,12 +659,12 @@ export default function GameUI({ inCoolMathGames, inGameDistribution, miniMapSho
 
   const hintLimitReached = singlePlayerRound && hintsUsedThisGame >= 2;
 
-  function showHint() {
+  const showHint = useCallback(() => {
     if (hintLimitReached || hintShown) return;
 
     setHintShown(true);
     setHintsUsedThisGame((prev) => prev + 1);
-  }
+  }, [hintLimitReached, hintShown, setHintShown]);
   useEffect(() => {
     if (dailyMode) return;
     loadLocation()
@@ -795,30 +795,43 @@ export default function GameUI({ inCoolMathGames, inGameDistribution, miniMapSho
       : singlePlayerRound
         ? `single:${gameOptions?.location || 'all'}:${singlePlayerRound?.round || ''}:${singlePlayerRound?.done ? 'done' : 'playing'}`
         : `free:${gameOptions?.location || 'all'}:${latLong?.lat ?? ''}:${latLong?.long ?? ''}`;
-  const miniMapFullscreenHotkeyEnabled = shouldShowMiniMap &&
-    !showAnswerOnMap &&
-    !forceHideMiniMap &&
-    !gameOptionsModalShown &&
-    !mapModal &&
-    !showDiscordModal &&
-    !explanationModalShown;
+  const hotkeysBlocked = showAnswerOnMap ||
+    gameOptionsModalShown ||
+    mapModal ||
+    showDiscordModal ||
+    explanationModalShown;
+  const miniMapFullscreenHotkeyEnabled = shouldShowMiniMap && !forceHideMiniMap && !hotkeysBlocked;
+  const hintHotkeyEnabled = !loading &&
+    !singlePlayerRound?.done &&
+    !onboarding?.completed &&
+    !multiplayerState?.inGame &&
+    !hintLimitReached &&
+    !hintShown &&
+    !hotkeysBlocked;
 
   useEffect(() => {
     function keydown(e) {
       if (e.defaultPrevented || e.repeat || e.ctrlKey || e.metaKey || e.altKey) return;
-      if (e.key?.toLowerCase() !== "f") return;
+      const key = e.key?.toLowerCase();
+      if (key !== "f" && key !== "h") return;
       if (isTypingTarget(e.target)) return;
-      if (!miniMapFullscreenHotkeyEnabled) return;
 
-      e.preventDefault();
-      toggleMiniMapFullscreen();
+      if (key === "f") {
+        if (!miniMapFullscreenHotkeyEnabled) return;
+        e.preventDefault();
+        toggleMiniMapFullscreen();
+      } else if (key === "h") {
+        if (!hintHotkeyEnabled) return;
+        e.preventDefault();
+        showHint();
+      }
     }
 
     document.addEventListener('keydown', keydown);
     return () => {
       document.removeEventListener('keydown', keydown);
     };
-  }, [miniMapFullscreenHotkeyEnabled, toggleMiniMapFullscreen]);
+  }, [hintHotkeyEnabled, miniMapFullscreenHotkeyEnabled, showHint, toggleMiniMapFullscreen]);
 
   return (
     <div className="gameUI">

--- a/components/gameUI.js
+++ b/components/gameUI.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react"
+import { useCallback, useEffect, useState, useRef } from "react"
 import dynamic from "next/dynamic";
 import { FaMap } from "react-icons/fa";
 import useWindowDimensions from "./useWindowDimensions";
@@ -28,6 +28,11 @@ const ONBOARDING_MIN_MANUAL_ADVANCE_MS = 6000;
 const MapWidget = dynamic(() => import("../components/Map"), { ssr: false });
 // import RoundOverScreen from "./roundOverScreen";
 const RoundOverScreen = dynamic(() => import("./roundOverScreen"), { ssr: false });
+
+function isTypingTarget(target) {
+  const tagName = target?.tagName?.toUpperCase?.();
+  return tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT" || target?.isContentEditable;
+}
 
 export default function GameUI({ inCoolMathGames, inGameDistribution, miniMapShown, setMiniMapShown, singlePlayerRound, setSinglePlayerRound, showDiscordModal, setShowDiscordModal, inCrazyGames, showPanoOnResult, setShowPanoOnResult, countryGuesserCorrect, setCountryGuesserCorrect, otherOptions, onboarding, setOnboarding, countryGuesser, options, timeOffset, ws, multiplayerState, backBtnPressed, setMultiplayerState, countryStreak, setCountryStreak, loading, setLoading, session, gameOptionsModalShown, setGameOptionsModalShown, mapModal, latLong, loadLocation, gameOptions, setGameOptions, showAnswer, setShowAnswer, pinPoint, setPinPoint, hintShown, setHintShown, showCountryButtons, setShowCountryButtons, welcomeOverlayShown, countryGuessrMode, dailyMode, onRoundsComplete }) {
   const { t: text } = useTranslation("common");
@@ -253,6 +258,14 @@ export default function GameUI({ inCoolMathGames, inGameDistribution, miniMapSho
   }
   const [miniMapExpanded, setMiniMapExpanded] = useState(false)
   const [miniMapFullscreen, setMiniMapFullscreen] = useState(false)
+  const toggleMiniMapFullscreen = useCallback(() => {
+    setMiniMapFullscreen((fullscreen) => {
+      if (!fullscreen) {
+        setMiniMapExpanded(true);
+      }
+      return !fullscreen;
+    });
+  }, []);
   const [roundStartTime, setRoundStartTime] = useState(null);
   const [lostCountryStreak, setLostCountryStreak] = useState(0);
   const [countryGuessrStreak, setCgStreak] = useState(() => {
@@ -521,7 +534,7 @@ export default function GameUI({ inCoolMathGames, inGameDistribution, miniMapSho
   useEffect(() => {
     function keydown(e) {
       // Don't trigger game actions if user is typing in an input field
-      if(e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable) {
+      if(isTypingTarget(e.target)) {
         return;
       }
 
@@ -782,6 +795,31 @@ export default function GameUI({ inCoolMathGames, inGameDistribution, miniMapSho
       : singlePlayerRound
         ? `single:${gameOptions?.location || 'all'}:${singlePlayerRound?.round || ''}:${singlePlayerRound?.done ? 'done' : 'playing'}`
         : `free:${gameOptions?.location || 'all'}:${latLong?.lat ?? ''}:${latLong?.long ?? ''}`;
+  const miniMapFullscreenHotkeyEnabled = shouldShowMiniMap &&
+    !showAnswerOnMap &&
+    !forceHideMiniMap &&
+    !gameOptionsModalShown &&
+    !mapModal &&
+    !showDiscordModal &&
+    !explanationModalShown;
+
+  useEffect(() => {
+    function keydown(e) {
+      if (e.defaultPrevented || e.repeat || e.ctrlKey || e.metaKey || e.altKey) return;
+      if (e.key?.toLowerCase() !== "f") return;
+      if (isTypingTarget(e.target)) return;
+      if (!miniMapFullscreenHotkeyEnabled) return;
+
+      e.preventDefault();
+      toggleMiniMapFullscreen();
+    }
+
+    document.addEventListener('keydown', keydown);
+    return () => {
+      document.removeEventListener('keydown', keydown);
+    };
+  }, [miniMapFullscreenHotkeyEnabled, toggleMiniMapFullscreen]);
+
   return (
     <div className="gameUI">
 
@@ -919,12 +957,7 @@ session={session}/>
 
 {!showAnswerOnMap && (
 <div className="mapCornerBtns desktop" style={{ visibility: miniMapExpanded ? 'visible' : 'hidden' }}>
-          <button className="cornerBtn" onClick={() => {
-            setMiniMapFullscreen(!miniMapFullscreen)
-            if(!miniMapFullscreen) {
-              setMiniMapExpanded(true)
-            }
-          }}>{miniMapFullscreen  ? (
+          <button className="cornerBtn" type="button" title="Toggle fullscreen map (F)" aria-label="Toggle fullscreen map" onClick={toggleMiniMapFullscreen}>{miniMapFullscreen  ? (
             <FaMinimize />
           ) : (
             <FaExpand />


### PR DESCRIPTION
## Summary

  Adds two keyboard shortcuts:
1.  **'F'** | Toggle minimap fullscreen
2.  **'H'** | Show hint 

  Also documents the available hotkeys in the README and adds a few improvements to the README

  ## Note

  These shortcuts only work when the Street View iframe is not focused. For example, they work when the minimap or page
  UI has focus, but not while keyboard input is being captured by Street View.