### PR TITLE
ws: the HTTP endpoints are express routes on the same uWS server

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "discord-webhook-node": "^1.1.8",
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
+    "fulmine.js": "^5.15.0",
     "formidable": "^3.5.1",
     "geojson-geometries-lookup": "^0.5.0",
     "google-auth-library": "^9.14.2",
@@ -77,7 +78,7 @@
     "redis": "^5.1.0",
     "sass": "^1.77.2",
     "sharp": "^0.33.5",
-    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.52.0",
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.69.0",
     "uuid": "^9.0.1",
     "web-vitals": "^5.3.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       formidable:
         specifier: ^3.5.1
         version: 3.5.4
+      fulmine.js:
+        specifier: ^5.15.0
+        version: 5.15.0
       geojson-geometries-lookup:
         specifier: ^0.5.0
         version: 0.5.0
@@ -141,8 +144,8 @@ importers:
         specifier: ^0.33.5
         version: 0.33.5
       uWebSockets.js:
-        specifier: github:uNetworking/uWebSockets.js#v20.52.0
-        version: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/cfc9a40d8132a34881813cec3d5f8e3a185b3ce3
+        specifier: github:uNetworking/uWebSockets.js#v20.69.0
+        version: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/dddd8ffd1b2c28a66022160923ca92f064cdacb4
       uuid:
         specifier: ^9.0.1
         version: 9.0.1
@@ -2406,8 +2409,14 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -2415,11 +2424,20 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/express-serve-static-core@5.1.3':
+    resolution: {integrity: sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
   '@types/hammerjs@2.0.46':
     resolution: {integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -2439,11 +2457,23 @@ packages:
   '@types/node@25.6.2':
     resolution: {integrity: sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==}
 
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
   '@types/react@19.1.17':
     resolution: {integrity: sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==}
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -2656,6 +2686,11 @@ packages:
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -3190,15 +3225,27 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -3906,6 +3953,9 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3921,6 +3971,9 @@ packages:
 
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  fast-zlib@2.0.1:
+    resolution: {integrity: sha512-DCoYgNagM2Bt1VIpXpdGnRx4LzqJeYG0oh6Nf/7cWo6elTXkFGMw9CrRCYYUIapYNrozYMoyDRflx9mgT3Awyw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4033,6 +4086,10 @@ packages:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fs-extra@0.26.7:
     resolution: {integrity: sha512-waKu+1KumRhYv8D8gMRCKJGAMI9pRnPuEb1mvgYD0f7wBscg+h6bW4FDTmEZhB9VKxvoTtxW+Y7bnIlB7zja6Q==}
 
@@ -4043,6 +4100,16 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  fulmine.js@5.15.0:
+    resolution: {integrity: sha512-gL4TA+pCqEjEMvLQDwOiNoU7wruRV2s5GLtn1J9RLcyp4SMVVfMd7iQdZiKdmbxd21DTk8k0+byaNN0Q38z72A==}
+    engines: {node: '>=22'}
+    hasBin: true
+    peerDependencies:
+      '@nestjs/platform-express': '>=10'
+    peerDependenciesMeta:
+      '@nestjs/platform-express':
+        optional: true
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -4290,6 +4357,10 @@ packages:
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   idb@7.1.1:
@@ -4917,6 +4988,10 @@ packages:
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
+
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
 
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
@@ -5667,6 +5742,10 @@ packages:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
   query-string@7.1.3:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
     engines: {node: '>=6'}
@@ -5686,6 +5765,10 @@ packages:
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
     engines: {node: '>= 0.6'}
 
   raw-body@2.5.3:
@@ -6162,6 +6245,10 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
+
   sift@17.1.3:
     resolution: {integrity: sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==}
 
@@ -6465,6 +6552,9 @@ packages:
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
+  tseep@1.3.1:
+    resolution: {integrity: sha512-ZPtfk1tQnZVyr7BPtbJ93qaAh2lZuIOpTMjhrYa4XctT8xe7t4SAW9LIxrySDuYMsfNNayE51E/WNGrNVgVicQ==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -6492,6 +6582,10 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -6516,9 +6610,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/cfc9a40d8132a34881813cec3d5f8e3a185b3ce3:
-    resolution: {tarball: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/cfc9a40d8132a34881813cec3d5f8e3a185b3ce3}
-    version: 20.52.0
+  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/dddd8ffd1b2c28a66022160923ca92f064cdacb4:
+    resolution: {tarball: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/dddd8ffd1b2c28a66022160923ca92f064cdacb4}
+    version: 20.69.0
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -9397,20 +9491,44 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 25.6.2
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 25.6.2
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/express-serve-static-core@5.1.3':
+    dependencies:
+      '@types/node': 25.6.2
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.3
+      '@types/serve-static': 2.2.0
 
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 25.6.2
 
   '@types/hammerjs@2.0.46': {}
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -9432,12 +9550,25 @@ snapshots:
     dependencies:
       undici-types: 7.19.2
 
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
+
   '@types/react@19.1.17':
     dependencies:
       csstype: 3.2.3
 
   '@types/responselike@1.0.3':
     dependencies:
+      '@types/node': 25.6.2
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 25.6.2
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
       '@types/node': 25.6.2
 
   '@types/stack-utils@2.0.3': {}
@@ -9636,6 +9767,8 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  acorn@8.18.0: {}
 
   agent-base@7.1.4: {}
 
@@ -10282,11 +10415,17 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.1.0: {}
+
   content-type@1.0.5: {}
+
+  content-type@2.1.0: {}
 
   convert-source-map@2.0.0: {}
 
   cookie-signature@1.0.7: {}
+
+  cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
 
@@ -10646,7 +10785,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -10676,7 +10815,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -10691,7 +10830,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11178,6 +11317,8 @@ snapshots:
 
   extend@3.0.2: {}
 
+  fast-decode-uri-component@1.0.1: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -11193,6 +11334,8 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-uri@3.1.2: {}
+
+  fast-zlib@2.0.1: {}
 
   fastq@1.20.1:
     dependencies:
@@ -11350,6 +11493,8 @@ snapshots:
 
   fresh@0.5.2: {}
 
+  fresh@2.0.0: {}
+
   fs-extra@0.26.7:
     dependencies:
       graceful-fs: 4.2.11
@@ -11362,6 +11507,32 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  fulmine.js@5.15.0:
+    dependencies:
+      '@types/express': 5.0.6
+      accepts: 2.0.0
+      acorn: 8.18.0
+      bytes: 3.1.2
+      compressible: 2.0.18
+      content-disposition: 1.1.0
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      encodeurl: 2.0.0
+      fast-decode-uri-component: 1.0.1
+      fast-zlib: 2.0.1
+      fresh: 2.0.0
+      iconv-lite: 0.7.3
+      mime-types: 3.0.2
+      ms: 2.1.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      statuses: 2.0.2
+      tseep: 1.3.1
+      type-is: 2.1.0
+      uWebSockets.js: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/dddd8ffd1b2c28a66022160923ca92f064cdacb4
+      vary: 1.1.2
 
   function-bind@1.1.2: {}
 
@@ -11676,6 +11847,10 @@ snapshots:
       diacritics: 1.3.0
 
   iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -12268,6 +12443,8 @@ snapshots:
   mdn-data@2.0.14: {}
 
   media-typer@0.3.0: {}
+
+  media-typer@1.1.1: {}
 
   memoize-one@5.2.1: {}
 
@@ -13328,6 +13505,11 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   query-string@7.1.3:
     dependencies:
       decode-uri-component: 0.2.2
@@ -13346,6 +13528,8 @@ snapshots:
   quickselect@2.0.0: {}
 
   range-parser@1.2.1: {}
+
+  range-parser@1.3.0: {}
 
   raw-body@2.5.3:
     dependencies:
@@ -13994,6 +14178,14 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   sift@17.1.3: {}
 
   siginfo@2.0.0: {}
@@ -14287,6 +14479,8 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
+  tseep@1.3.1: {}
+
   tslib@2.8.1: {}
 
   type-check@0.4.0:
@@ -14305,6 +14499,12 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.1.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -14345,7 +14545,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/cfc9a40d8132a34881813cec3d5f8e3a185b3ce3: {}
+  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/dddd8ffd1b2c28a66022160923ca92f064cdacb4: {}
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/serverUtils/setCorsHeaders.js
+++ b/serverUtils/setCorsHeaders.js
@@ -1,6 +1,0 @@
-
-export default function setCorsHeaders(response) {
-  response.writeHeader('Access-Control-Allow-Origin', '*');
-  response.writeHeader('Access-Control-Allow-Methods', 'GET');
-  response.writeHeader('Access-Control-Allow-Headers', 'content-type');
-}

--- a/ws/ws.js
+++ b/ws/ws.js
@@ -25,13 +25,14 @@
 // this back to the function form.
 import 'dotenv/config';
 import uws from 'uWebSockets.js';
+import express from 'fulmine.js';
+import cors from 'cors';
 import fs from 'fs';
 import Player from './classes/Player.js';
 import { v4 as uuidv4 } from 'uuid';
 import User, { USERNAME_COLLATION } from '../models/User.js';
 import mongoose from 'mongoose';
 import Game from './classes/Game.js';
-import setCorsHeaders from '../serverUtils/setCorsHeaders.js';
 import { getActivePlayerCount, getPlatformDistribution } from '../serverUtils/playerCounts.js';
 
 import lookup from "coordinate_to_country"
@@ -711,51 +712,40 @@ process.on('unhandledRejection', (reason, promise) => {
   console.error('Unhandled rejection', reason, promise, currentDate());
 });
 // uWebSockets.js
-let app = uws.App({
+// fulmine.js is a drop-in Express replacement that runs on uWebSockets.js: the routes below are
+// ordinary Express routes and `app.uwsApp` is the very uWS application the websocket is on, so
+// this is still one server on one port.
+const app = express();
 
+app.use(cors({ methods: 'GET', allowedHeaders: 'content-type' }));
+
+app.listen(port, '0.0.0.0', () => {
+  log('**WS Server started on port** ' + port);
 });
-app.listen('0.0.0.0', port, (ws) => {
-  if (ws) {
-    log('**WS Server started on port** ' + port);
+
+app.get('/', (req, res) => {
+  // count all the headers
+  let headerKb = 0;
+  for (const [key, value] of Object.entries(req.headers)) {
+    headerKb += key.length + String(value).length;
   }
+  headerKb = headerKb / 1024;
+
+  res.type('html').send("WorldGuessr - Powered by uWebSockets.js<br>Headers: "+headerKb.toFixed(2)+'kb');
 });
 
-app.get('/', (res, req) => {
-
-      // count all the headers
-      let headerKb = 0;
-      req.forEach((key, value) => {
-
-        headerKb += key.length + value.length;
-
-      });
-      headerKb = headerKb / 1024;
-
-
-  setCorsHeaders(res);
-  res.writeHeader('Content-Type', 'text/html');
-  res.writeStatus('200 OK');
-  res.end("WorldGuessr - Powered by uWebSockets.js<br>Headers: "+headerKb.toFixed(2)+'kb');
+app.get('/playercnt', (req, res) => {
+  res.type('text/plain').send(String(getActivePlayerCount()));
 });
 
-app.get('/playercnt', (res) => {
-  setCorsHeaders(res);
-  res.writeHeader('Content-Type', 'text/plain');
-  res.writeStatus('200 OK');
-  res.end(String(getActivePlayerCount()));
-});
-
-app.get('/platformdist', (res) => {
-  setCorsHeaders(res);
-  res.writeHeader('Content-Type', 'application/json');
-  res.writeStatus('200 OK');
-  res.end(JSON.stringify(getPlatformDistribution()));
+app.get('/platformdist', (req, res) => {
+  res.json(getPlatformDistribution());
 });
 
 // maintenance mode
 if (process.env.MAINTENANCE_SECRET) {
   const maintenanceSecret = process.env.MAINTENANCE_SECRET;
-  app.get(`/setmaintenance/${maintenanceSecret}/true`, (res) => {
+  app.get(`/setmaintenance/${maintenanceSecret}/true`, (req, res) => {
     maintenanceMode = true;
     // notify all players
     for (const player of players.values()) {
@@ -765,14 +755,12 @@ if (process.env.MAINTENANCE_SECRET) {
       });
     }
 
-    setCorsHeaders(res);
-    res.writeHeader('Content-Type', 'text/plain');
-    res.end('ok');
+    res.type('text/plain').send('ok');
     console.log('Maintenance mode started');
 
   });
 
-  app.get(`/setmaintenance/${maintenanceSecret}/false`, (res) => {
+  app.get(`/setmaintenance/${maintenanceSecret}/false`, (req, res) => {
     maintenanceMode = false;
     // notify all players
     for (const player of players.values()) {
@@ -782,14 +770,12 @@ if (process.env.MAINTENANCE_SECRET) {
       });
     }
 
-    setCorsHeaders(res);
-    res.writeHeader('Content-Type', 'text/plain');
-    res.end('ok');
+    res.type('text/plain').send('ok');
     console.log('Maintenance mode ended');
   });
 
   // get all players & ips
-  app.get(`/getips/${maintenanceSecret}`, (res) => {
+  app.get(`/getips/${maintenanceSecret}`, (req, res) => {
     const playerData = [];
     for (const player of players.values()) {
       playerData.push({
@@ -799,12 +785,10 @@ if (process.env.MAINTENANCE_SECRET) {
       });
     }
 
-    setCorsHeaders(res);
-    res.writeHeader('Content-Type', 'application/json');
-    res.end(JSON.stringify(playerData));
+    res.json(playerData);
   });
-  app.get(`/banIp/${maintenanceSecret}/:ip`, (res, req) => {
-    const ip = req.getParameter(0);
+  app.get(`/banIp/${maintenanceSecret}/:ip`, (req, res) => {
+    const ip = req.params.ip;
     bannedIps.add(ip);
     let cnt = 0;
     // kick all players with this ip
@@ -824,39 +808,30 @@ if (process.env.MAINTENANCE_SECRET) {
     }
 
 
-    setCorsHeaders(res);
-    res.writeHeader('Content-Type', 'text/htmk');
-    res.end('kick count: ' + cnt+'<br>banned ip: '+ip+'<br> all ips: '+[...bannedIps].join('<br>'));
+    res.type('text/htmk').send('kick count: ' + cnt+'<br>banned ip: '+ip+'<br> all ips: '+[...bannedIps].join('<br>'));
     console.log('Banned ip', ip, 'kicked', cnt, currentDate());
   });
-  app.get(`/unbanIp/${maintenanceSecret}/:ip`, (res, req) => {
-    const ip = req.getParameter(0);
+  app.get(`/unbanIp/${maintenanceSecret}/:ip`, (req, res) => {
+    const ip = req.params.ip;
     bannedIps.delete(ip);
 
-    setCorsHeaders(res);
-    res.writeHeader('Content-Type', 'text/plain');
-    res.end('ok');
+    res.type('text/plain').send('ok');
     console.log('Unbanned ip', ip, currentDate());
   });
-  app.get(`/getIpCounts/${maintenanceSecret}`, (res) => {
+  app.get(`/getIpCounts/${maintenanceSecret}`, (req, res) => {
     const ipCounts = [...ipConnectionCount.entries()].map(([ip, cnt]) => ({ ip, cnt }));
-    setCorsHeaders(res);
-    res.writeHeader('Content-Type', 'application/json');
-    res.end(JSON.stringify(ipCounts));
+    res.json(ipCounts);
   });
 
-  app.get(`/enforce-ban/${maintenanceSecret}/:accountId`, (res, req) => {
-    const accountId = req.getParameter(0);
+  app.get(`/enforce-ban/${maintenanceSecret}/:accountId`, (req, res) => {
+    const accountId = req.params.accountId;
 
     if (!accountId) {
-      setCorsHeaders(res);
-      res.writeStatus('400 Bad Request');
-      res.writeHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({
+      res.status(400).json({
         success: false,
         error: 'Account ID required',
         playerFound: false
-      }));
+      });
       return;
     }
 
@@ -865,15 +840,13 @@ if (process.env.MAINTENANCE_SECRET) {
 
     if (!player) {
       // Player not connected - this is OK, return success
-      setCorsHeaders(res);
-      res.writeHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({
+      res.json({
         success: true,
         playerFound: false,
         playerDisconnected: false,
         wasInGame: false,
         message: 'Player not currently connected'
-      }));
+      });
       console.log('Ban enforcement: Player not connected', accountId, currentDate());
       return;
     }
@@ -927,9 +900,7 @@ if (process.env.MAINTENANCE_SECRET) {
     }
 
     // Return success response
-    setCorsHeaders(res);
-    res.writeHeader('Content-Type', 'application/json');
-    res.end(JSON.stringify({
+    res.json({
       success: true,
       playerFound: true,
       playerDisconnected: true,
@@ -937,7 +908,7 @@ if (process.env.MAINTENANCE_SECRET) {
       message: gameInfo.wasInGame
         ? `Player banned and disconnected from ${gameInfo.gameType}${gameInfo.opponentRefunded ? '. Opponent will be awarded win.' : ''}`
         : 'Player banned and disconnected'
-    }));
+    });
   });
 
   // Cosmetics push: the HTTP purchase/equip route calls this so a live ws
@@ -955,19 +926,12 @@ if (process.env.MAINTENANCE_SECRET) {
   //
   // Absent params are left ALONE (a partial update must not wipe the other
   // fields); an explicitly empty value clears that field.
-  app.get(`/cosmetics-updated/${maintenanceSecret}/:accountId`, (res, req) => {
-    // Read everything off `req` FIRST: a uWS request object is only valid
-    // inside the synchronous body of its handler.
-    const accountId = req.getParameter(0);
-    const query = new URLSearchParams(req.getQuery() || '');
+  app.get(`/cosmetics-updated/${maintenanceSecret}/:accountId`, (req, res) => {
+    const accountId = req.params.accountId;
+    const query = new URLSearchParams(req.url.split('?')[1] || '');
 
     if (!accountId) {
-      // writeStatus BEFORE writeHeader, always — uWS writes them in call order
-      // and a status after a header is a protocol error.
-      setCorsHeaders(res);
-      res.writeStatus('400 Bad Request');
-      res.writeHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({ success: false, error: 'Account ID required', playerFound: false }));
+      res.status(400).json({ success: false, error: 'Account ID required', playerFound: false });
       return;
     }
 
@@ -976,9 +940,7 @@ if (process.env.MAINTENANCE_SECRET) {
       // Offline is the NORMAL case for a shop purchase (most buying happens
       // outside a live game), so this is a 200 with playerFound:false — not an
       // error the caller has to special-case or retry.
-      setCorsHeaders(res);
-      res.writeHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({ success: true, playerFound: false, broadcast: false }));
+      res.json({ success: true, playerFound: false, broadcast: false });
       return;
     }
 
@@ -1021,9 +983,7 @@ if (process.env.MAINTENANCE_SECRET) {
       broadcast = true;
     }
 
-    setCorsHeaders(res);
-    res.writeHeader('Content-Type', 'application/json');
-    res.end(JSON.stringify({ success: true, playerFound: true, broadcast }));
+    res.json({ success: true, playerFound: true, broadcast });
   });
 
 }
@@ -1082,7 +1042,7 @@ function updateGameOptions(game, rounds=5, timePerRound=30, location="all", nm=f
           game.sendStateUpdate(true);
 
         }
-app.ws('/wg', {
+app.uwsApp.ws('/wg', {
   /* Options */
   compression: uws.SHARED_COMPRESSOR,
   maxPayloadLength: 64 * 1024 * 1024,


### PR DESCRIPTION
`ws/ws.js` serves eleven HTTP endpoints beside the game socket, and each one is written against uWS
by hand: `setCorsHeaders(res)`, `res.writeStatus(...)` before `res.writeHeader(...)` in the right
order, `res.end(JSON.stringify(...))`, `req.getParameter(0)` read synchronously before the request
object dies. That is the part this changes.

fulmine.js is a drop-in Express 5 replacement that runs on µWebSockets.js. `express()` here is that,
so the endpoints become ordinary routes with `res.json()`, `res.type().send()` and `req.params.ip`,
CORS becomes one `cors()` middleware, and `serverUtils/setCorsHeaders.js` goes away. The game socket
is untouched: it registers on `app.uwsApp`, the same uWS application, with the same behaviour
object, the same custom `upgrade` and the same user data. One server, one port, as before. About 90
lines less.

`uWebSockets.js` moves from v20.52.0 to v20.69.0 so there is one copy of it in the tree rather than
two, since fulmine pins that tag.

I ran it: the server starts, `/`, `/playercnt`, `/platformdist`, `/getips`, `/getIpCounts`,
`/banIp/:ip`, `/unbanIp/:ip`, `/setmaintenance/true|false`, `/enforce-ban/:accountId` and
`/cosmetics-updated/:accountId` answer what they answered before, with
`access-control-allow-origin: *`, and a websocket client connects to `/wg` and receives the time
sync message. Without Mongo and Redis, so no real game round, and no speed number is claimed here.

One difference worth knowing: express appends `; charset=utf-8` to the text content types.

I maintain fulmine.js, so weigh the recommendation accordingly.