### PR TITLE
Add autoBanCheaters capability to moderator dashboard

### DIFF
--- a/api/mod/auditLogs.js
+++ b/api/mod/auditLogs.js
@@ -127,6 +127,11 @@ export default async function handler(req, res) {
       nameChange: log.nameChange,
       eloRefund: log.eloRefund,
       suspiciousGames: log.suspiciousGames || [], // Mod-flagged evidence games (staff-only)
+      isAutoBan: log.isAutoBan || false,
+      autoBanWorkflow: log.autoBanWorkflow || null,
+      autoBanOffenseCount: log.autoBanOffenseCount || null,
+      autoBanPreviousBanExpiresAt: log.autoBanPreviousBanExpiresAt || null,
+      autoBanRefundSince: log.autoBanRefundSince || null,
       relatedReports: log.relatedReports?.length || 0,
       createdAt: log.createdAt
     }));

--- a/api/mod/autoBanCheaters.js
+++ b/api/mod/autoBanCheaters.js
@@ -1,0 +1,426 @@
+import User from '../../models/User.js';
+import Game from '../../models/Game.js';
+import Report from '../../models/Report.js';
+import ModerationLog from '../../models/ModerationLog.js';
+import DailyChallengeScore from '../../models/DailyChallengeScore.js';
+import DailyLeaderboard from '../../models/DailyLeaderboard.js';
+import { syncedClearCache } from '../../serverUtils/cacheBus.js';
+import { invalidateDailyPublicCache } from '../dailyChallenge/results.js';
+import { addBannedIdentity } from '../../serverUtils/bannedIdentities.js';
+import { refundEloToOpponentsSince } from '../../serverUtils/eloRefunds.js';
+import {
+  TEMP_BAN_DAYS,
+  TEMP_BAN_DURATION_MS,
+  WORKFLOW_NAME,
+  getEffectiveBanStatus,
+  checkRepeatOffender,
+  shouldSkipSuspect,
+  buildTempBanReason,
+  buildPermBanReason
+} from '../../serverUtils/autoBanLogic.js';
+
+/**
+ * Remove a user from every daily leaderboard surface (same as takeAction.js).
+ */
+async function scrubFromDailyLeaderboards(targetUserId) {
+  const userIdStr = targetUserId.toString();
+
+  const affectedDates = await DailyChallengeScore.find({
+    userId: targetUserId,
+    hidden: { $ne: true },
+    disqualified: { $ne: true }
+  }).distinct('date');
+
+  const [dcResult, dlResult] = await Promise.all([
+    DailyChallengeScore.updateMany(
+      { userId: targetUserId, hidden: { $ne: true } },
+      { $set: { hidden: true } }
+    ),
+    DailyLeaderboard.updateMany(
+      { 'leaderboard.userId': userIdStr },
+      { $pull: { leaderboard: { userId: userIdStr } } }
+    )
+  ]);
+
+  for (const date of affectedDates) {
+    try {
+      invalidateDailyPublicCache(date);
+    } catch (e) {
+      // invalidateDailyPublicCache may not be available in test env; non-critical
+      console.warn('[autoBanCheaters] invalidateDailyPublicCache failed:', e?.message || e);
+    }
+  }
+
+  return {
+    dailyChallengeScoresHidden: dcResult.modifiedCount,
+    dailyLeaderboardsScrubbed: dlResult.modifiedCount
+  };
+}
+
+async function enforceBanViaWs(targetUserId) {
+  if (!process.env.MAINTENANCE_SECRET) return;
+  try {
+    const wsPort = process.env.WS_PORT || 3002;
+    const wsUrl = `http://localhost:${wsPort}/enforce-ban/${process.env.MAINTENANCE_SECRET}/${targetUserId}`;
+    const wsResponse = await fetch(wsUrl, { method: 'GET' });
+    const wsResult = await wsResponse.json();
+    console.log('[autoBanCheaters] WebSocket ban enforcement result:', wsResult);
+  } catch (error) {
+    console.error('[autoBanCheaters] Failed to enforce ban via WebSocket (non-critical):', error.message);
+  }
+}
+
+/**
+ * Compute suspects using the exact same aggregation as suspicious5k.js
+ * Returns enriched suspects array (without ban/report enrichment needed for ban logic)
+ */
+async function findSuspects({ days, minPoints, minRounds, limit }) {
+  const sinceDate = new Date();
+  sinceDate.setDate(sinceDate.getDate() - days);
+
+  const results = await Game.aggregate([
+    {
+      $match: {
+        gameType: 'ranked_duel',
+        endedAt: { $gte: sinceDate }
+      }
+    },
+    { $unwind: '$rounds' },
+    { $unwind: '$rounds.playerGuesses' },
+    {
+      $match: {
+        'rounds.playerGuesses.accountId': { $ne: null }
+      }
+    },
+    {
+      $facet: {
+        highScores: [
+          { $match: { 'rounds.playerGuesses.points': { $gte: minPoints } } },
+          {
+            $group: {
+              _id: '$rounds.playerGuesses.accountId',
+              username: { $last: '$rounds.playerGuesses.username' },
+              highRounds: { $sum: 1 },
+              avgPoints: { $avg: '$rounds.playerGuesses.points' },
+              games: { $addToSet: '$gameId' },
+              lastSeen: { $max: '$endedAt' },
+              // Also track earliest suspicious game after a given date if needed,
+              // but we keep lastSeen for repeat-offender check
+              firstHighScoreAt: { $min: '$endedAt' }
+            }
+          },
+          { $addFields: { gameCount: { $size: '$games' } } },
+          { $match: { highRounds: { $gte: minRounds } } }
+        ],
+        totalRounds: [
+          {
+            $group: {
+              _id: '$rounds.playerGuesses.accountId',
+              totalRounds: { $sum: 1 },
+              totalAvgPoints: { $avg: '$rounds.playerGuesses.points' }
+            }
+          }
+        ]
+      }
+    }
+  ]);
+
+  const { highScores, totalRounds } = results[0];
+
+  const totalRoundsMap = {};
+  totalRounds.forEach(r => {
+    totalRoundsMap[r._id] = { totalRounds: r.totalRounds, totalAvgPoints: r.totalAvgPoints };
+  });
+
+  const suspects = highScores.map(s => ({
+    accountId: s._id,
+    username: s.username,
+    highRounds: s.highRounds,
+    totalRounds: totalRoundsMap[s._id]?.totalRounds || s.highRounds,
+    highRoundPct: Math.round((s.highRounds / (totalRoundsMap[s._id]?.totalRounds || s.highRounds)) * 100),
+    avgPointsHigh: Math.round(s.avgPoints),
+    avgPointsAll: Math.round(totalRoundsMap[s._id]?.totalAvgPoints || 0),
+    gameCount: s.gameCount,
+    lastSeen: s.lastSeen,
+    firstHighScoreAt: s.firstHighScoreAt,
+    games: s.games
+  }));
+
+  suspects.sort((a, b) => b.highRounds - a.highRounds);
+
+  return suspects.slice(0, limit);
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  const { secret, days = 30, minPoints = 4950, minRounds = 10, limit = 100 } = req.body || {};
+
+  if (!secret || typeof secret !== 'string') {
+    return res.status(400).json({ message: 'Invalid secret' });
+  }
+
+  try {
+    const requestingUser = await User.findOne({ secret });
+    if (!requestingUser || !requestingUser.staff) {
+      return res.status(403).json({ message: 'Unauthorized' });
+    }
+
+    const moderator = requestingUser;
+
+    const suspects = await findSuspects({ days, minPoints, minRounds, limit });
+
+    if (suspects.length === 0) {
+      return res.status(200).json({
+        message: 'No suspects found',
+        tempBans: [],
+        permanentBans: [],
+        skipped: [],
+        totalProcessed: 0,
+        filters: { days, minPoints, minRounds }
+      });
+    }
+
+    const accountIds = suspects.map(s => s.accountId);
+    const users = await User.find(
+      { _id: { $in: accountIds } },
+      { _id: 1, username: 1, banned: 1, banType: 1, banExpiresAt: 1, elo: 1, secret: 1, email: 1, appleId: 1, crazyGamesId: 1, staff: 1 }
+    ).lean();
+
+    const userMap = {};
+    users.forEach(u => { userMap[u._id.toString()] = u; });
+
+    const tempBans = [];
+    const permanentBans = [];
+    const skipped = [];
+
+    const now = new Date();
+
+    for (const suspect of suspects) {
+      const accountId = suspect.accountId.toString();
+      const user = userMap[accountId];
+
+      // Check previous autoBan perm bans early for shouldSkipSuspect
+      let previousAutoPermBans = [];
+      let previousAutoTempBans = [];
+
+      // Determine effective banned status (handle expired temp bans)
+      const effectiveBanStatus = getEffectiveBanStatus(user, now);
+      if (effectiveBanStatus.expired) {
+        try {
+          await User.findByIdAndUpdate(accountId, {
+            banned: false,
+            banType: 'none',
+            banExpiresAt: null
+          });
+        } catch (e) {
+          console.warn('[autoBanCheaters] failed to auto-clear expired ban for', accountId, e?.message);
+        }
+      }
+
+      // We need perm count before shouldSkip; query optimistically if user exists
+      if (user) {
+        previousAutoPermBans = await ModerationLog.find({
+          'targetUser.accountId': accountId,
+          actionType: 'ban_permanent',
+          isAutoBan: true,
+          autoBanWorkflow: WORKFLOW_NAME
+        }).lean();
+      }
+
+      const skipCheck = shouldSkipSuspect(user, effectiveBanStatus, previousAutoPermBans.length);
+      if (skipCheck.skip) {
+        skipped.push({ accountId, username: user?.username || suspect.username, reason: skipCheck.reason });
+        continue;
+      }
+
+      // Check previous autoBan temp bans for this user
+      previousAutoTempBans = await ModerationLog.find({
+        'targetUser.accountId': accountId,
+        actionType: 'ban_temporary',
+        isAutoBan: true,
+        autoBanWorkflow: WORKFLOW_NAME
+      }).sort({ createdAt: -1 }).lean();
+
+      if (previousAutoTempBans.length === 0) {
+        // FIRST OFFENSE - 14 day temp ban
+        const expiresAt = new Date(Date.now() + TEMP_BAN_DURATION_MS);
+        const internalReason = buildTempBanReason(suspect, { days, minPoints, minRounds });
+        const publicNote = 'Using external help is not allowed, if you think the ban was unfair join the discord server and appeal the ban.';
+
+        // Update user
+        await User.findByIdAndUpdate(accountId, {
+          banned: true,
+          banType: 'temporary',
+          banExpiresAt: expiresAt,
+          banReason: internalReason,
+          banPublicNote: publicNote
+        });
+
+        await enforceBanViaWs(accountId);
+        try { syncedClearCache(`userAuth_${user.secret}`); } catch (e) { console.warn('[autoBanCheaters] cache clear failed', e?.message); }
+
+        let leaderboardScrubResult = null;
+        try {
+          leaderboardScrubResult = await scrubFromDailyLeaderboards(accountId);
+        } catch (e) {
+          console.error('[autoBanCheaters] leaderboard scrub failed for temp ban', accountId, e?.message);
+        }
+
+        const moderationLog = await ModerationLog.create({
+          targetUser: {
+            accountId: accountId,
+            username: user.username
+          },
+          moderator: {
+            accountId: moderator._id.toString(),
+            username: moderator.username
+          },
+          actionType: 'ban_temporary',
+          duration: TEMP_BAN_DURATION_MS,
+          durationString: `${TEMP_BAN_DAYS} days`,
+          expiresAt: expiresAt,
+          reason: internalReason,
+          notes: publicNote,
+          isAutoBan: true,
+          autoBanWorkflow: WORKFLOW_NAME,
+          autoBanOffenseCount: 1,
+          autoBanPreviousBanExpiresAt: null,
+          suspiciousGames: (suspect.games || []).slice(0, 20).map(gid => ({ gameId: gid, opponentUsername: null, opponentAccountId: null }))
+        });
+
+        tempBans.push({
+          accountId,
+          username: user.username,
+          expiresAt,
+          highRounds: suspect.highRounds,
+          avgPointsHigh: suspect.avgPointsHigh,
+          gameCount: suspect.gameCount,
+          moderationLogId: moderationLog._id,
+          leaderboardScrub: leaderboardScrubResult
+        });
+
+      } else {
+        // Has previous temp ban(s) - check if repeat offender via helper
+        let repeatCheck = checkRepeatOffender(previousAutoTempBans, now, suspect.lastSeen);
+
+        // If helper says no game after expiry based on lastSeen, double-check via DB query for precision
+        if (!repeatCheck.isRepeat && repeatCheck.reason && repeatCheck.reason.startsWith('No cheating game after')) {
+          const prevExpiresAt = repeatCheck.previousTempBan?.expiresAt ? new Date(repeatCheck.previousTempBan.expiresAt) : null;
+          if (prevExpiresAt) {
+            const gameAfter = await Game.findOne({
+              gameType: 'ranked_duel',
+              'players.accountId': accountId,
+              endedAt: { $gt: prevExpiresAt }
+            }).lean();
+            if (gameAfter) {
+              repeatCheck = { isRepeat: true, reason: null, previousTempBan: repeatCheck.previousTempBan, refundSince: prevExpiresAt };
+            }
+          }
+        }
+
+        if (!repeatCheck.isRepeat) {
+          skipped.push({ accountId, username: user.username, reason: repeatCheck.reason });
+          continue;
+        }
+
+        const prevExpiresAt = repeatCheck.previousTempBan.expiresAt ? new Date(repeatCheck.previousTempBan.expiresAt) : new Date(repeatCheck.refundSince);
+        const refundSince = repeatCheck.refundSince;
+
+        // REPEAT OFFENDER - permanent ban
+        const internalReason = buildPermBanReason(suspect, { days, minPoints, minRounds }, prevExpiresAt);
+        const publicNote = 'Using external help is not allowed, if you think the ban was unfair join the discord server and appeal the ban. (Repeat offense - permanent ban)';
+
+        await User.findByIdAndUpdate(accountId, {
+          banned: true,
+          banType: 'permanent',
+          banExpiresAt: null,
+          banReason: internalReason,
+          banPublicNote: publicNote
+        });
+
+        // Blocklist identity
+        try {
+          await addBannedIdentity({
+            user: user,
+            type: 'ban_permanent',
+            reason: internalReason,
+            publicNote: publicNote,
+            moderator,
+          });
+        } catch (e) {
+          console.warn('[autoBanCheaters] addBannedIdentity failed', e?.message);
+        }
+
+        await enforceBanViaWs(accountId);
+        try { syncedClearCache(`userAuth_${user.secret}`); } catch (e) { console.warn('[autoBanCheaters] cache clear failed', e?.message); }
+
+        let leaderboardScrubResult = null;
+        try {
+          leaderboardScrubResult = await scrubFromDailyLeaderboards(accountId);
+        } catch (e) {
+          console.error('[autoBanCheaters] leaderboard scrub failed for perm ban', accountId, e?.message);
+        }
+
+        // ELO refund for opponents who lost after temp ban expiry
+        let eloRefundResult = null;
+        try {
+          eloRefundResult = await refundEloToOpponentsSince(accountId, user.username, refundSince);
+        } catch (e) {
+          console.error('[autoBanCheaters] elo refund failed for', accountId, e?.message, e?.stack);
+          eloRefundResult = { totalRefunded: 0, opponentsAffected: 0, gamesProcessed: 0, error: e?.message };
+        }
+
+        const moderationLog = await ModerationLog.create({
+          targetUser: {
+            accountId: accountId,
+            username: user.username
+          },
+          moderator: {
+            accountId: moderator._id.toString(),
+            username: moderator.username
+          },
+          actionType: 'ban_permanent',
+          reason: internalReason,
+          notes: publicNote,
+          eloRefund: eloRefundResult || { totalRefunded: 0, opponentsAffected: 0, gamesProcessed: 0 },
+          isAutoBan: true,
+          autoBanWorkflow: WORKFLOW_NAME,
+          autoBanOffenseCount: 2,
+          autoBanPreviousBanExpiresAt: prevExpiresAt,
+          autoBanRefundSince: refundSince,
+          suspiciousGames: (suspect.games || []).slice(0, 20).map(gid => ({ gameId: gid, opponentUsername: null, opponentAccountId: null }))
+        });
+
+        permanentBans.push({
+          accountId,
+          username: user.username,
+          highRounds: suspect.highRounds,
+          avgPointsHigh: suspect.avgPointsHigh,
+          gameCount: suspect.gameCount,
+          lastSeen: suspect.lastSeen,
+          previousTempBanExpiresAt: prevExpiresAt,
+          refundSince,
+          eloRefund: eloRefundResult,
+          moderationLogId: moderationLog._id,
+          leaderboardScrub: leaderboardScrubResult
+        });
+      }
+    }
+
+    return res.status(200).json({
+      message: `autoBanCheaters completed: ${tempBans.length} temp banned, ${permanentBans.length} permanently banned, ${skipped.length} skipped`,
+      tempBans,
+      permanentBans,
+      skipped,
+      totalProcessed: suspects.length,
+      filters: { days, minPoints, minRounds }
+    });
+
+  } catch (err) {
+    console.error('autoBanCheaters error:', err);
+    return res.status(500).json({ message: 'Internal server error', error: err.message });
+  }
+}

--- a/components/modDashboard.js
+++ b/components/modDashboard.js
@@ -225,6 +225,11 @@ export default function ModDashboard({ session }) {
   const [suspectsMinPoints, setSuspectsMinPoints] = useState(4950);
   const [suspectsMinRounds, setSuspectsMinRounds] = useState(10);
 
+  // autoBanCheaters state
+  const [autoBanLoading, setAutoBanLoading] = useState(false);
+  const [autoBanResult, setAutoBanResult] = useState(null);
+  const [showAutoBanConfirm, setShowAutoBanConfirm] = useState(false);
+
   // Clear messages after delay
   useEffect(() => {
     if (successMessage) {
@@ -677,6 +682,39 @@ export default function ModDashboard({ session }) {
       setError(err.message);
     } finally {
       setSuspectsLoading(false);
+    }
+  };
+
+  const autoBanCheaters = async (days, minPoints, minRounds) => {
+    setAutoBanLoading(true);
+    setAutoBanResult(null);
+    setError(null);
+    try {
+      const response = await fetch(window.cConfig?.apiUrl+'/api/mod/autoBanCheaters', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          secret: session.token.secret,
+          days: days ?? suspectsDays,
+          minPoints: minPoints ?? suspectsMinPoints,
+          minRounds: minRounds ?? suspectsMinRounds
+        })
+      });
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData.message || 'Failed to auto-ban cheaters');
+      }
+      const data = await response.json();
+      setAutoBanResult(data);
+      setSuccessMessage(data.message || `autoBanCheaters completed: ${data.tempBans?.length || 0} temp, ${data.permanentBans?.length || 0} perm`);
+      // Refresh suspects list to reflect new ban statuses
+      fetchSuspects(days, minPoints, minRounds);
+    } catch (err) {
+      setError(err.message);
+      setAutoBanResult({ error: err.message });
+    } finally {
+      setAutoBanLoading(false);
+      setShowAutoBanConfirm(false);
     }
   };
 
@@ -2672,6 +2710,16 @@ export default function ModDashboard({ session }) {
                             </span>
                           </div>
                         )}
+                        {log.isAutoBan && (
+                          <div className={styles.auditLogRow}>
+                            <span className={styles.auditLogLabel}>Auto-Ban:</span>
+                            <span className={styles.auditLogValue} style={{ color: '#d29922' }}>
+                              🤖 {log.autoBanWorkflow || 'autoBanCheaters'} - {log.autoBanOffenseCount === 1 ? 'First offense (14d temp)' : log.autoBanOffenseCount === 2 ? 'Repeat offense (perm)' : `Offense #${log.autoBanOffenseCount}`}
+                              {log.autoBanPreviousBanExpiresAt && ` (prev expired ${new Date(log.autoBanPreviousBanExpiresAt).toLocaleDateString()})`}
+                              {log.autoBanRefundSince && ` (refund since ${new Date(log.autoBanRefundSince).toLocaleDateString()})`}
+                            </span>
+                          </div>
+                        )}
                       </div>
                     </div>
                   ))}
@@ -2854,7 +2902,92 @@ export default function ModDashboard({ session }) {
                 <button className={styles.searchBtn} onClick={() => fetchSuspects()} disabled={suspectsLoading}>
                   {suspectsLoading ? 'Loading...' : 'Search'}
                 </button>
+                <button
+                  className={styles.searchBtn}
+                  onClick={() => setShowAutoBanConfirm(true)}
+                  disabled={autoBanLoading || suspectsLoading}
+                  style={{ backgroundColor: '#d29922', color: '#000', marginLeft: '8px' }}
+                  title="autoBanCheaters: 14-day temp ban first offenders, perm ban repeat offenders with ELO refund"
+                >
+                  {autoBanLoading ? 'Banning...' : '⚖️ autoBanCheaters'}
+                </button>
               </div>
+
+              {showAutoBanConfirm && (
+                <div className={styles.modalOverlay} style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }}>
+                  <div className={styles.modal} style={{ background: '#0d1117', border: '1px solid #30363d', borderRadius: '8px', padding: '24px', maxWidth: '520px', width: '90%' }}>
+                    <h3 style={{ marginTop: 0 }}>⚖️ Confirm autoBanCheaters</h3>
+                    <p>
+                      This will search suspicious accounts using the current filters
+                      (last {suspectsDays} days, min {suspectsMinPoints} pts, min {suspectsMinRounds} rounds):
+                    </p>
+                    <ul style={{ fontSize: '0.9rem', color: '#c9d1d9' }}>
+                      <li><strong>First-time offenders</strong> will receive a <strong>14-day temporary ban</strong>.</li>
+                      <li><strong>Repeat offenders</strong> (previously temp-banned by this workflow, whose ban expired and who cheated again in a game after expiry) will be <strong>permanently banned</strong>.</li>
+                      <li>After a permanent ban, <strong>ELO will be refunded</strong> to opponents who lost ranked games against the cheater <em>after their temp ban expired</em> until they were caught.</li>
+                    </ul>
+                    <p style={{ fontSize: '0.85rem', color: '#8b949e' }}>
+                      This action is logged in the audit logs with isAutoBan=true and workflow=&apos;autoBanCheaters&apos;. Currently banned users are skipped.
+                    </p>
+                    <div style={{ display: 'flex', gap: '12px', justifyContent: 'flex-end', marginTop: '16px' }}>
+                      <button className={styles.searchBtn} onClick={() => setShowAutoBanConfirm(false)} disabled={autoBanLoading}>
+                        Cancel
+                      </button>
+                      <button
+                        className={styles.searchBtn}
+                        onClick={() => autoBanCheaters()}
+                        disabled={autoBanLoading}
+                        style={{ backgroundColor: '#da3633', color: '#fff' }}
+                      >
+                        {autoBanLoading ? 'Processing...' : 'Confirm autoBanCheaters'}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {autoBanResult && (
+                <div style={{ margin: '16px 0', padding: '16px', background: autoBanResult.error ? 'rgba(248,81,73,0.1)' : 'rgba(63,185,80,0.1)', border: `1px solid ${autoBanResult.error ? '#f85149' : '#3fb950'}`, borderRadius: '8px' }}>
+                  {autoBanResult.error ? (
+                    <p style={{ color: '#f85149', margin: 0 }}>❌ {autoBanResult.error}</p>
+                  ) : (
+                    <>
+                      <p style={{ margin: '0 0 8px 0', fontWeight: 600 }}>
+                        ✅ {autoBanResult.message}
+                      </p>
+                      <div style={{ fontSize: '0.9rem', display: 'grid', gap: '8px' }}>
+                        {autoBanResult.tempBans?.length > 0 && (
+                          <div>
+                            <strong>Temp banned (14d) - {autoBanResult.tempBans.length}:</strong>{' '}
+                            {autoBanResult.tempBans.map(u => u.username).join(', ')}
+                          </div>
+                        )}
+                        {autoBanResult.permanentBans?.length > 0 && (
+                          <div>
+                            <strong>Permanently banned - {autoBanResult.permanentBans.length}:</strong>{' '}
+                            {autoBanResult.permanentBans.map(u => {
+                              const refund = u.eloRefund;
+                              const refundText = refund?.totalRefunded ? ` (refunded ${refund.totalRefunded} ELO to ${refund.opponentsAffected} opponents)` : '';
+                              return `${u.username}${refundText}`;
+                            }).join(', ')}
+                          </div>
+                        )}
+                        {autoBanResult.skipped?.length > 0 && (
+                          <div style={{ color: '#8b949e' }}>
+                            <strong>Skipped - {autoBanResult.skipped.length}:</strong>{' '}
+                            {autoBanResult.skipped.slice(0, 10).map(s => `${s.username} (${s.reason})`).join(', ')}
+                            {autoBanResult.skipped.length > 10 && ` ...and ${autoBanResult.skipped.length - 10} more`}
+                          </div>
+                        )}
+                        {(!autoBanResult.tempBans?.length && !autoBanResult.permanentBans?.length && !autoBanResult.skipped?.length) && (
+                          <span>No actions taken</span>
+                        )}
+                      </div>
+                      <button onClick={() => setAutoBanResult(null)} style={{ marginTop: '8px', fontSize: '0.8rem' }}>Dismiss</button>
+                    </>
+                  )}
+                </div>
+              )}
 
               {suspectsLoading ? (
                 <div className={styles.loadingText}>Scanning duel rounds...</div>

--- a/models/ModerationLog.js
+++ b/models/ModerationLog.js
@@ -117,6 +117,28 @@ const moderationLogSchema = new mongoose.Schema({
     default: []
   },
 
+  // Auto-ban workflow tracking (autoBanCheaters)
+  isAutoBan: {
+    type: Boolean,
+    default: false
+  },
+  autoBanWorkflow: {
+    type: String,
+    default: null // e.g. 'autoBanCheaters'
+  },
+  autoBanOffenseCount: {
+    type: Number,
+    default: null // 1 = first offense (14-day temp ban), 2 = repeat offense (perm ban)
+  },
+  autoBanPreviousBanExpiresAt: {
+    type: Date,
+    default: null // When the prior 14-day temp ban expired (for repeat offenders)
+  },
+  autoBanRefundSince: {
+    type: Date,
+    default: null // Start of ELO refund window for perm bans (previous temp ban expiry)
+  },
+
   // Timestamp
   createdAt: {
     type: Date,
@@ -129,6 +151,7 @@ moderationLogSchema.index({ 'targetUser.accountId': 1, createdAt: -1 });
 moderationLogSchema.index({ 'moderator.accountId': 1, createdAt: -1 });
 moderationLogSchema.index({ actionType: 1, createdAt: -1 });
 moderationLogSchema.index({ createdAt: -1 });
+moderationLogSchema.index({ 'targetUser.accountId': 1, isAutoBan: 1, autoBanWorkflow: 1, actionType: 1, createdAt: -1 });
 
 const ModerationLog = mongoose.models.ModerationLog || mongoose.model('ModerationLog', moderationLogSchema);
 

--- a/serverUtils/autoBanLogic.js
+++ b/serverUtils/autoBanLogic.js
@@ -1,0 +1,109 @@
+/**
+ * Pure logic helpers for autoBanCheaters workflow.
+ * Extracted to be unit-testable without DB.
+ */
+
+export const TEMP_BAN_DAYS = 14;
+export const TEMP_BAN_DURATION_MS = TEMP_BAN_DAYS * 24 * 60 * 60 * 1000;
+export const WORKFLOW_NAME = 'autoBanCheaters';
+
+/**
+ * Determine if a user is effectively banned, accounting for expired temp bans.
+ * @param {Object} user - User doc with banned, banType, banExpiresAt
+ * @param {Date} now
+ * @returns {{effectivelyBanned: boolean, effectiveBanType: string, expired: boolean}}
+ */
+export function getEffectiveBanStatus(user, now = new Date()) {
+  if (!user || !user.banned) {
+    return { effectivelyBanned: false, effectiveBanType: 'none', expired: false };
+  }
+  if (user.banType === 'temporary' && user.banExpiresAt) {
+    if (now >= new Date(user.banExpiresAt)) {
+      return { effectivelyBanned: false, effectiveBanType: 'none', expired: true };
+    }
+    return { effectivelyBanned: true, effectiveBanType: 'temporary', expired: false };
+  }
+  if (user.banType === 'permanent') {
+    return { effectivelyBanned: true, effectiveBanType: 'permanent', expired: false };
+  }
+  // Legacy banned flag without banType
+  if (user.banned) {
+    return { effectivelyBanned: true, effectiveBanType: user.banType || 'none', expired: false };
+  }
+  return { effectivelyBanned: false, effectiveBanType: 'none', expired: false };
+}
+
+/**
+ * Check if a suspect is a repeat offender based on previous autoBan temp bans.
+ *
+ * @param {Array} previousAutoTempBans - ModerationLog entries sorted desc by createdAt, filtered to isAutoBan, workflow, ban_temporary
+ * @param {Date} now
+ * @param {Date|string|null} lastSeen - suspect.lastSeen (max endedAt of suspicious games)
+ * @returns {{isRepeat: boolean, reason: string|null, previousTempBan: Object|null, refundSince: Date|null}}
+ */
+export function checkRepeatOffender(previousAutoTempBans, now, lastSeen) {
+  if (!previousAutoTempBans || previousAutoTempBans.length === 0) {
+    return { isRepeat: false, reason: null, previousTempBan: null, refundSince: null };
+  }
+
+  const latestTempBan = previousAutoTempBans[0];
+  const prevExpiresAt = latestTempBan.expiresAt ? new Date(latestTempBan.expiresAt) : null;
+
+  if (!prevExpiresAt || isNaN(prevExpiresAt.getTime())) {
+    return { isRepeat: false, reason: 'Previous auto temp ban missing expiresAt', previousTempBan: latestTempBan, refundSince: null };
+  }
+
+  if (now < prevExpiresAt) {
+    return { isRepeat: false, reason: `Previous auto temp ban not yet expired (expires ${prevExpiresAt.toISOString()})`, previousTempBan: latestTempBan, refundSince: null };
+  }
+
+  // Must have cheating game after expiry
+  let hasGameAfterExpiry = false;
+  if (lastSeen) {
+    const lastSeenDate = new Date(lastSeen);
+    if (!isNaN(lastSeenDate.getTime()) && lastSeenDate > prevExpiresAt) {
+      hasGameAfterExpiry = true;
+    }
+  }
+
+  if (!hasGameAfterExpiry) {
+    return { isRepeat: false, reason: `No cheating game after previous temp ban expiry (${prevExpiresAt.toISOString()})`, previousTempBan: latestTempBan, refundSince: null };
+  }
+
+  return { isRepeat: true, reason: null, previousTempBan: latestTempBan, refundSince: prevExpiresAt };
+}
+
+/**
+ * Determine which suspects to process, skipping banned/staff etc.
+ * Pure helper for testing decision table.
+ */
+export function shouldSkipSuspect(user, effectiveBanStatus, previousPermBansCount) {
+  if (!user) return { skip: true, reason: 'User not found' };
+  if (user.staff) return { skip: true, reason: 'Staff member' };
+  if (effectiveBanStatus.effectivelyBanned) {
+    if (effectiveBanStatus.effectiveBanType === 'permanent') {
+      return { skip: true, reason: 'Already permanently banned' };
+    }
+    return { skip: true, reason: 'Currently temporarily banned' };
+  }
+  if (previousPermBansCount > 0) {
+    return { skip: true, reason: 'Already permanently banned by autoBanCheaters' };
+  }
+  return { skip: false, reason: null };
+}
+
+/**
+ * Build internal reason strings for audit logs
+ */
+export function buildTempBanReason(suspect, filters) {
+  const { highRounds, avgPointsHigh, gameCount, highRoundPct } = suspect;
+  const { days, minPoints, minRounds } = filters;
+  return `[${WORKFLOW_NAME}] First offense - suspicious 5k activity detected: ${highRounds} rounds >=${minPoints} pts (avg ${avgPointsHigh}), ${gameCount} games in last ${days} days, highRoundPct=${highRoundPct}%`;
+}
+
+export function buildPermBanReason(suspect, filters, prevExpiresAt) {
+  const { highRounds, avgPointsHigh, gameCount, highRoundPct, lastSeen } = suspect;
+  const { days, minPoints } = filters;
+  const lastSeenStr = lastSeen ? new Date(lastSeen).toISOString() : 'unknown';
+  return `[${WORKFLOW_NAME}] Repeat offense - suspicious 5k activity after 14-day temp ban expired on ${new Date(prevExpiresAt).toISOString()}: ${highRounds} rounds >=${minPoints} pts (avg ${avgPointsHigh}), ${gameCount} games in last ${days} days, highRoundPct=${highRoundPct}%, lastSeen=${lastSeenStr}`;
+}

--- a/serverUtils/eloRefunds.js
+++ b/serverUtils/eloRefunds.js
@@ -368,3 +368,32 @@ export async function refundEloForReportedGames(bannedUserId, bannedUsername, re
 
   return processRefundGames(bannedAccountId, bannedUsername, gameMongoIds, moderationLogId);
 }
+
+/**
+ * Refund ELO to opponents who lost ELO playing against a banned user after a certain date.
+ * Used by autoBanCheaters for repeat offenders: refunds only games that occurred
+ * after the previous 14-day temp ban expired, up to when they were caught again.
+ *
+ * @param {string} bannedUserId - The MongoDB _id of the banned user
+ * @param {string} bannedUsername - The username of the banned user
+ * @param {Date|string} sinceDate - Only refund games endedAt >= this date
+ * @param {string} moderationLogId - The ID of the moderation log entry (optional)
+ * @returns {Object} Summary of refunds (same shape as refundEloToOpponents)
+ */
+export async function refundEloToOpponentsSince(bannedUserId, bannedUsername, sinceDate, moderationLogId = null) {
+  if (!sinceDate) {
+    return refundEloToOpponents(bannedUserId, bannedUsername, moderationLogId);
+  }
+
+  const bannedAccountId = bannedUserId.toString();
+  const since = new Date(sinceDate);
+
+  const gameMongoIds = await Game.find({
+    gameType: { $in: ['ranked_duel', '2v2'] },
+    'players.accountId': bannedAccountId,
+    eloRefunded: { $ne: true },
+    endedAt: { $gte: since }
+  }).distinct('_id');
+
+  return processRefundGames(bannedAccountId, bannedUsername, gameMongoIds, moderationLogId);
+}

--- a/test/autoBanCheaters.test.js
+++ b/test/autoBanCheaters.test.js
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TEMP_BAN_DAYS,
+  TEMP_BAN_DURATION_MS,
+  WORKFLOW_NAME,
+  getEffectiveBanStatus,
+  checkRepeatOffender,
+  shouldSkipSuspect,
+  buildTempBanReason,
+  buildPermBanReason
+} from '../serverUtils/autoBanLogic.js';
+
+describe('autoBanLogic constants', () => {
+  it('has 14 day temp ban', () => {
+    expect(TEMP_BAN_DAYS).toBe(14);
+    expect(TEMP_BAN_DURATION_MS).toBe(14 * 24 * 60 * 60 * 1000);
+  });
+
+  it('workflow name is autoBanCheaters', () => {
+    expect(WORKFLOW_NAME).toBe('autoBanCheaters');
+  });
+});
+
+describe('getEffectiveBanStatus', () => {
+  const now = new Date('2024-06-01T12:00:00Z');
+
+  it('returns not banned for unbanned user', () => {
+    const result = getEffectiveBanStatus({ banned: false }, now);
+    expect(result.effectivelyBanned).toBe(false);
+    expect(result.effectiveBanType).toBe('none');
+  });
+
+  it('returns not banned for null user', () => {
+    const result = getEffectiveBanStatus(null, now);
+    expect(result.effectivelyBanned).toBe(false);
+  });
+
+  it('detects expired temp ban', () => {
+    const user = {
+      banned: true,
+      banType: 'temporary',
+      banExpiresAt: new Date('2024-05-01T12:00:00Z') // before now
+    };
+    const result = getEffectiveBanStatus(user, now);
+    expect(result.effectivelyBanned).toBe(false);
+    expect(result.expired).toBe(true);
+  });
+
+  it('detects active temp ban', () => {
+    const user = {
+      banned: true,
+      banType: 'temporary',
+      banExpiresAt: new Date('2024-06-10T12:00:00Z') // after now
+    };
+    const result = getEffectiveBanStatus(user, now);
+    expect(result.effectivelyBanned).toBe(true);
+    expect(result.effectiveBanType).toBe('temporary');
+  });
+
+  it('detects permanent ban', () => {
+    const user = { banned: true, banType: 'permanent' };
+    const result = getEffectiveBanStatus(user, now);
+    expect(result.effectivelyBanned).toBe(true);
+    expect(result.effectiveBanType).toBe('permanent');
+  });
+});
+
+describe('checkRepeatOffender', () => {
+  const now = new Date('2024-06-15T12:00:00Z');
+
+  it('returns not repeat when no previous bans', () => {
+    const result = checkRepeatOffender([], now, new Date());
+    expect(result.isRepeat).toBe(false);
+    expect(result.previousTempBan).toBe(null);
+  });
+
+  it('returns not repeat when previous ban missing expiresAt', () => {
+    const bans = [{ createdAt: new Date(), expiresAt: null }];
+    const result = checkRepeatOffender(bans, now, new Date());
+    expect(result.isRepeat).toBe(false);
+    expect(result.reason).toContain('missing expiresAt');
+  });
+
+  it('returns not repeat when previous ban not yet expired', () => {
+    const bans = [{ expiresAt: new Date('2024-06-20T12:00:00Z') }];
+    const result = checkRepeatOffender(bans, now, new Date('2024-06-16T12:00:00Z'));
+    expect(result.isRepeat).toBe(false);
+    expect(result.reason).toContain('not yet expired');
+  });
+
+  it('returns not repeat when no game after expiry', () => {
+    const bans = [{ expiresAt: new Date('2024-06-01T12:00:00Z') }];
+    const lastSeen = new Date('2024-05-20T12:00:00Z'); // before expiry
+    const result = checkRepeatOffender(bans, now, lastSeen);
+    expect(result.isRepeat).toBe(false);
+    expect(result.reason).toContain('No cheating game after');
+  });
+
+  it('returns repeat when game after expiry and ban expired', () => {
+    const expiresAt = new Date('2024-06-01T12:00:00Z');
+    const bans = [{ expiresAt }];
+    const lastSeen = new Date('2024-06-05T12:00:00Z'); // after expiry
+    const result = checkRepeatOffender(bans, now, lastSeen);
+    expect(result.isRepeat).toBe(true);
+    expect(result.refundSince).toEqual(expiresAt);
+    expect(result.previousTempBan).toEqual(bans[0]);
+  });
+
+  it('handles string dates for lastSeen', () => {
+    const expiresAt = new Date('2024-06-01T12:00:00Z');
+    const bans = [{ expiresAt }];
+    const result = checkRepeatOffender(bans, now, '2024-06-10T12:00:00Z');
+    expect(result.isRepeat).toBe(true);
+  });
+
+  it('uses most recent temp ban when multiple', () => {
+    const older = { expiresAt: new Date('2024-01-01T12:00:00Z'), id: 'older' };
+    const newer = { expiresAt: new Date('2024-06-01T12:00:00Z'), id: 'newer' };
+    // Sorted desc by createdAt, so newer first
+    const bans = [newer, older];
+    const result = checkRepeatOffender(bans, now, new Date('2024-06-05T12:00:00Z'));
+    expect(result.isRepeat).toBe(true);
+    expect(result.previousTempBan.id).toBe('newer');
+  });
+});
+
+describe('shouldSkipSuspect', () => {
+  it('skips when user not found', () => {
+    const result = shouldSkipSuspect(null, { effectivelyBanned: false }, 0);
+    expect(result.skip).toBe(true);
+    expect(result.reason).toBe('User not found');
+  });
+
+  it('skips staff', () => {
+    const result = shouldSkipSuspect({ staff: true }, { effectivelyBanned: false }, 0);
+    expect(result.skip).toBe(true);
+    expect(result.reason).toBe('Staff member');
+  });
+
+  it('skips permanently banned', () => {
+    const result = shouldSkipSuspect({ username: 'a' }, { effectivelyBanned: true, effectiveBanType: 'permanent' }, 0);
+    expect(result.skip).toBe(true);
+    expect(result.reason).toContain('permanently banned');
+  });
+
+  it('skips currently temp banned', () => {
+    const result = shouldSkipSuspect({ username: 'a' }, { effectivelyBanned: true, effectiveBanType: 'temporary' }, 0);
+    expect(result.skip).toBe(true);
+    expect(result.reason).toContain('temporarily banned');
+  });
+
+  it('skips if already perm banned by autoBan', () => {
+    const result = shouldSkipSuspect({ username: 'a' }, { effectivelyBanned: false }, 1);
+    expect(result.skip).toBe(true);
+    expect(result.reason).toContain('autoBanCheaters');
+  });
+
+  it('does not skip valid suspect', () => {
+    const result = shouldSkipSuspect({ username: 'a' }, { effectivelyBanned: false }, 0);
+    expect(result.skip).toBe(false);
+  });
+});
+
+describe('buildTempBanReason / buildPermBanReason', () => {
+  const suspect = {
+    highRounds: 15,
+    avgPointsHigh: 4980,
+    gameCount: 3,
+    highRoundPct: 75,
+    lastSeen: new Date('2024-06-10T12:00:00Z')
+  };
+  const filters = { days: 30, minPoints: 4950, minRounds: 10 };
+
+  it('builds temp ban reason with workflow tag', () => {
+    const reason = buildTempBanReason(suspect, filters);
+    expect(reason).toContain('[autoBanCheaters]');
+    expect(reason).toContain('First offense');
+    expect(reason).toContain('15');
+    expect(reason).toContain('4950');
+  });
+
+  it('builds perm ban reason with expiry and repeat tag', () => {
+    const prevExpiry = new Date('2024-06-01T12:00:00Z');
+    const reason = buildPermBanReason(suspect, filters, prevExpiry);
+    expect(reason).toContain('[autoBanCheaters]');
+    expect(reason).toContain('Repeat offense');
+    expect(reason).toContain(prevExpiry.toISOString());
+    expect(reason).toContain('15');
+  });
+});
+
+describe('autoBan workflow integration logic', () => {
+  it('first offense -> temp, repeat after expiry -> perm', () => {
+    const now1 = new Date('2024-06-01T12:00:00Z');
+    // First time: no previous bans
+    let check1 = checkRepeatOffender([], now1, new Date('2024-06-01T10:00:00Z'));
+    expect(check1.isRepeat).toBe(false);
+
+    // Simulate temp ban created, expires 14 days later
+    const expiresAt = new Date(now1.getTime() + TEMP_BAN_DURATION_MS);
+    expect(expiresAt.getTime() - now1.getTime()).toBe(14 * 24 * 60 * 60 * 1000);
+
+    // Before expiry, not repeat
+    const nowBeforeExpiry = new Date('2024-06-10T12:00:00Z');
+    let check2 = checkRepeatOffender([{ expiresAt }], nowBeforeExpiry, new Date('2024-06-10T10:00:00Z'));
+    expect(check2.isRepeat).toBe(false);
+    expect(check2.reason).toContain('not yet expired');
+
+    // After expiry, with game after expiry -> repeat
+    const nowAfterExpiry = new Date('2024-06-20T12:00:00Z');
+    let check3 = checkRepeatOffender([{ expiresAt }], nowAfterExpiry, new Date('2024-06-18T10:00:00Z'));
+    expect(check3.isRepeat).toBe(true);
+    expect(check3.refundSince).toEqual(expiresAt);
+
+    // After expiry, but game was before expiry -> not repeat
+    let check4 = checkRepeatOffender([{ expiresAt }], nowAfterExpiry, new Date('2024-06-10T10:00:00Z'));
+    expect(check4.isRepeat).toBe(false);
+  });
+
+  it('refund window should be from temp ban expiry to catch time', () => {
+    const expiresAt = new Date('2024-06-01T12:00:00Z');
+    const now = new Date('2024-06-20T12:00:00Z');
+    const check = checkRepeatOffender([{ expiresAt }], now, new Date('2024-06-18T10:00:00Z'));
+    expect(check.refundSince).toEqual(expiresAt);
+    // The endpoint should query games with endedAt >= refundSince
+    // This ensures opponents who lost after expiry get refunded, not before
+    const refundSince = check.refundSince;
+    const gameBefore = new Date('2024-05-20T12:00:00Z');
+    const gameAfter = new Date('2024-06-10T12:00:00Z');
+    expect(gameBefore >= refundSince).toBe(false);
+    expect(gameAfter >= refundSince).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Adds autoBanCheaters option to moderator dashboard (5k Tracker tab).

### Changes
- **New endpoint** `POST /api/mod/autoBanCheaters` (same auth/params as suspicious5k):
  - Searches suspicious accounts using same aggregation as suspicious5k (days, minPoints, minRounds, limit)
  - First-time offenders (no prior autoBan temp ban): 14-day temporary ban
  - Repeat offenders (previously auto-banned 14d, ban expired, and cheating game after expiry): permanent ban
  - After perm ban, refunds ELO to opponents who lost ranked games after temp ban expiry until caught (via new `refundEloToOpponentsSince`)

- **New** `serverUtils/autoBanLogic.js` with pure testable helpers: `getEffectiveBanStatus`, `checkRepeatOffender`, `shouldSkipSuspect`, `buildTempBanReason`, `buildPermBanReason`, constants.

- **Modified** `serverUtils/eloRefunds.js`: added `refundEloToOpponentsSince(bannedUserId, bannedUsername, sinceDate, moderationLogId)` which queries games with `endedAt >= sinceDate`.

- **Modified** `models/ModerationLog.js`: added `isAutoBan`, `autoBanWorkflow`, `autoBanOffenseCount`, `autoBanPreviousBanExpiresAt`, `autoBanRefundSince` + index.

- **Modified** `api/mod/auditLogs.js`: expose autoBan fields.

- **Modified** `components/modDashboard.js`:
  - Added state `autoBanLoading`, `autoBanResult`, `showAutoBanConfirm`
  - Added function `autoBanCheaters()` calling new endpoint
  - Added button "⚖️ autoBanCheaters" in 5k Tracker tab with confirmation modal and result display
  - Shows autoBan info in audit logs

- **New test** `test/autoBanCheaters.test.js`: 24 unit tests covering constants, effective ban status, repeat detection, skip logic, reason building, workflow integration, refund window.

### Workflow
1. Mod clicks autoBanCheaters in 5k Tracker, confirms.
2. System finds suspects (same as suspicious5k).
3. For each suspect:
   - Skip if staff, currently banned, already perm-banned.
   - If no prior autoBan temp ban → 14d temp ban (logged with isAutoBan=true, offenseCount=1)
   - Else if prior temp ban expired and suspect has game after expiry → perm ban + ELO refund since expiry (logged offenseCount=2, refundSince=prevExpiry)
   - Else skip with reason.

### ELO Refund
- Only after perm ban.
- Only games `endedAt >= tempBanExpiry` up to catch time.
- Uses existing `processRefundGames` logic for ELO + win/loss reversal, capped, conversion, etc.

